### PR TITLE
fix(ui): accessibility and UX improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ When a labeled container starts, the controller pauses it briefly, attaches it t
 
 See [DEVELOPMENT.md](DEVELOPMENT.md).
 
+## Accessibility
+
+The extension UI targets [WCAG 2.1 Level AA](https://www.w3.org/TR/WCAG21/) conformance. To report an accessibility issue, please [open a GitHub issue](https://github.com/imdsutil/barnacle-imds-proxy/issues).
+
 ## License
 
 Apache 2.0 — see [LICENSE](LICENSE).

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -18,7 +18,7 @@ import { useDockerDesktopService } from './services/dockerDesktopService';
 import logo from './logo.svg';
 import {
   CONTAINER_POLL_INTERVAL_MS,
-  SNACKBAR_AUTO_HIDE_DURATION_MS,
+  SNACKBAR_SUCCESS_DURATION_MS,
   GITHUB_REPO_URL,
   IMDS_PROXY_ENABLED_LABEL,
   BACKEND_REQUEST_TIMEOUT_MS,
@@ -333,7 +333,7 @@ export function App() {
 
       <Snackbar
         open={snackbarOpen}
-        autoHideDuration={SNACKBAR_AUTO_HIDE_DURATION_MS}
+        autoHideDuration={snackbarSeverity === 'success' ? SNACKBAR_SUCCESS_DURATION_MS : null}
         onClose={handleSnackbarClose}
         anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
       >

--- a/ui/src/__tests__/settingsForm.test.tsx
+++ b/ui/src/__tests__/settingsForm.test.tsx
@@ -102,6 +102,60 @@ describe('SettingsForm', () => {
     expect(client.extension.vm.service.post).not.toHaveBeenCalled();
   });
 
+  it('validates URL format before saving', async () => {
+    const service = createMockService({
+      getSettings: vi.fn().mockResolvedValue({ url: SETTINGS_URL }),
+    });
+    const showSnackbar = vi.fn();
+    const client = createMockDockerDesktopClient();
+
+    render(
+      <SettingsForm
+        ddClient={client as any}
+        service={service}
+        showSnackbar={showSnackbar}
+      />
+    );
+
+    const input = await screen.findByLabelText(/IMDS server URL/i);
+    fireEvent.change(input, { target: { value: 'not a url' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /save settings/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Enter a valid URL (e.g. http://localhost:8080)')).toBeTruthy();
+    });
+    expect(client.extension.vm.service.post).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed URLs', async () => {
+    const service = createMockService({
+      getSettings: vi.fn().mockResolvedValue({ url: SETTINGS_URL }),
+    });
+    const showSnackbar = vi.fn();
+    const client = createMockDockerDesktopClient();
+
+    render(
+      <SettingsForm
+        ddClient={client as any}
+        service={service}
+        showSnackbar={showSnackbar}
+      />
+    );
+
+    const input = await screen.findByLabelText(/IMDS server URL/i);
+    const invalidUrls = ['not a url', 'ftp://example.com', 'http://', 'http:///\\localhost:3000'];
+
+    for (const invalidUrl of invalidUrls) {
+      fireEvent.change(input, { target: { value: invalidUrl } });
+      fireEvent.click(screen.getByRole('button', { name: /save settings/i }));
+      await waitFor(() => {
+        expect(screen.getByText('Enter a valid URL (e.g. http://localhost:8080)')).toBeTruthy();
+      });
+    }
+    expect(client.extension.vm.service.post).not.toHaveBeenCalled();
+  });
+
   it('saves settings and debounces the button', async () => {
     const service = createMockService({
       getSettings: vi.fn().mockResolvedValue({ url: '' }),

--- a/ui/src/components/ContainersTable.tsx
+++ b/ui/src/components/ContainersTable.tsx
@@ -257,13 +257,13 @@ export function ContainersTable({
                                     sx={{
                                       fontFamily: 'monospace',
                                       color: 'text.secondary',
-                                      minWidth: 240,
-                                      flexShrink: 0,
+                                      minWidth: 160,
+                                      wordBreak: 'break-all',
                                     }}
                                   >
                                     {key}
                                   </Typography>
-                                  <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+                                  <Typography variant="body2" sx={{ fontFamily: 'monospace', wordBreak: 'break-all' }}>
                                     {value}
                                   </Typography>
                                 </Stack>

--- a/ui/src/components/ContainersTable.tsx
+++ b/ui/src/components/ContainersTable.tsx
@@ -137,8 +137,10 @@ export function ContainersTable({
                     onClick={() => handleRowClick(container.containerId)}
                     onKeyDown={(event) => {
                       if (event.key === 'Enter' || event.key === ' ') {
-                        event.preventDefault();
-                        handleRowClick(container.containerId);
+                        if (event.target === event.currentTarget) {
+                          event.preventDefault();
+                          handleRowClick(container.containerId);
+                        }
                       }
                     }}
                     tabIndex={0}

--- a/ui/src/components/ContainersTable.tsx
+++ b/ui/src/components/ContainersTable.tsx
@@ -34,6 +34,7 @@ import {
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
+import Link from '@mui/material/Link';
 import { ContainerInfo } from '../types';
 import { CONTAINER_ID_DISPLAY_LENGTH } from '../constants';
 import { cleanContainerName } from '../utils/containerUtils';
@@ -291,14 +292,16 @@ export function ContainersTable({
       <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mt: 0.5 }}>
         <Box>
           {proxyUnreachable && (
-            <Typography
+            <Link
+              component="button"
               variant="body2"
               color="error"
               onClick={onProxyHelp}
-              sx={{ cursor: onProxyHelp ? 'pointer' : 'default', textDecoration: onProxyHelp ? 'underline' : 'none' }}
+              disabled={!onProxyHelp}
+              sx={{ textDecoration: 'underline' }}
             >
               Extension backend not responding — list may be outdated
-            </Typography>
+            </Link>
           )}
         </Box>
         <Typography variant="body2" color="text.secondary">

--- a/ui/src/components/SettingsForm.tsx
+++ b/ui/src/components/SettingsForm.tsx
@@ -44,6 +44,7 @@ export function SettingsForm({ ddClient, service, showSnackbar, proxyUnreachable
   const [isSaving, setIsSaving] = useState(false);
   const [isLoadingSettings, setIsLoadingSettings] = useState(false);
   const [isDebouncing, setIsDebouncing] = useState(false);
+  const [hasBeenSaved, setHasBeenSaved] = useState(false);
 
   // Track mount status to prevent state updates after unmount during async settings load
   const isMountedRef = useRef(false);
@@ -125,6 +126,7 @@ export function SettingsForm({ ddClient, service, showSnackbar, proxyUnreachable
 
       // Update saved state to disable button
       setSavedUrl(url);
+      setHasBeenSaved(true);
       showSnackbar('Settings saved', 'success');
 
       // Disable save button to prevent rapid re-submission
@@ -174,6 +176,7 @@ export function SettingsForm({ ddClient, service, showSnackbar, proxyUnreachable
             onChange={(e) => {
               setUrl(e.target.value);
               setUrlError('');
+              setHasBeenSaved(false);
             }}
             variant="outlined"
             size="small"
@@ -188,7 +191,7 @@ export function SettingsForm({ ddClient, service, showSnackbar, proxyUnreachable
             disabled={isSaving || url === savedUrl || isDebouncing || proxyUnreachable}
             sx={{ alignSelf: 'flex-start' }}
           >
-            {isSaving ? 'Saving...' : url === savedUrl && savedUrl !== '' ? 'Saved' : 'Save Settings'}
+            {isSaving ? 'Saving...' : hasBeenSaved ? 'Saved' : 'Save Settings'}
           </Button>
         </>
       )}

--- a/ui/src/components/SettingsForm.tsx
+++ b/ui/src/components/SettingsForm.tsx
@@ -39,7 +39,7 @@ interface SettingsFormProps {
 
 export function SettingsForm({ ddClient, service, showSnackbar, proxyUnreachable, onProxyHelp }: SettingsFormProps) {
   const [url, setUrl] = useState('');
-  const [urlError, setUrlError] = useState(false);
+  const [urlError, setUrlError] = useState('');
   const [savedUrl, setSavedUrl] = useState('');
   const [isSaving, setIsSaving] = useState(false);
   const [isLoadingSettings, setIsLoadingSettings] = useState(false);
@@ -93,16 +93,20 @@ export function SettingsForm({ ddClient, service, showSnackbar, proxyUnreachable
 
   const handleSave = async () => {
     // Reset errors
-    setUrlError(false);
+    setUrlError('');
 
     if (!ddClient) {
       showSnackbar('Docker Desktop client unavailable', 'error');
       return;
     }
 
-    // Validate that URL is filled
+    // Validate URL
     if (!url) {
-      setUrlError(true);
+      setUrlError('URL is required');
+      return;
+    }
+    if (!/^https?:\/\/[^/\\]/.test(url)) {
+      setUrlError('Enter a valid URL (e.g. http://localhost:8080)');
       return;
     }
 
@@ -169,12 +173,12 @@ export function SettingsForm({ ddClient, service, showSnackbar, proxyUnreachable
             value={url}
             onChange={(e) => {
               setUrl(e.target.value);
-              setUrlError(false);
+              setUrlError('');
             }}
             variant="outlined"
             size="small"
-            error={urlError}
-            helperText={urlError ? 'URL is required' : 'Examples: http://localhost:8080, https://api.example.com'}
+            error={!!urlError}
+            helperText={urlError || 'Examples: http://localhost:8080, https://api.example.com'}
             fullWidth
             spellCheck={false}
           />

--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -28,9 +28,10 @@ export const SAVE_DEBOUNCE_MS = 1000;
 export const CONTAINER_ID_DISPLAY_LENGTH = 12;
 
 /**
- * How long to show snackbar notifications before auto-hiding (in milliseconds)
+ * How long to show success snackbar notifications before auto-hiding (in milliseconds).
+ * Error notifications use autoHideDuration={null} and require manual dismissal.
  */
-export const SNACKBAR_AUTO_HIDE_DURATION_MS = 6000;
+export const SNACKBAR_SUCCESS_DURATION_MS = 3000;
 
 /**
  * GitHub repository URL for documentation


### PR DESCRIPTION
## Summary

- Fix keyboard accessibility: row `onKeyDown` now guards against child focus, so Enter/Space on copy buttons triggers the copy rather than expanding the row
- URL validation: regex guard rejects non-http schemes, empty hostnames, and malformed URLs before saving
- Backend unreachable message now uses MUI `Link component="button"` — in tab order and keyboard activatable
- Success snackbars auto-hide after 3s; error snackbars require manual dismissal
- "Saved" button label resets to "Save Settings" only when the user edits the URL field
- Label key/value cells in expanded rows now wrap on long content
- Add WCAG 2.1 AA conformance target to README

## Test plan

- [x] Tab through container table rows — Enter/Space on copy buttons should copy, not expand the row
- [x] Enter a malformed URL in Settings (e.g. `ftp://`, `http://`, `not-a-url`) — should show inline error and block save
- [x] Simulate backend unreachable — footer error message should be focusable and activatable via keyboard
- [x] Trigger a copy success — snackbar should dismiss after ~3s
- [x] Trigger a save error — snackbar should stay until manually closed
- [x] Save settings, then edit the URL — button should revert from "Saved" to "Save Settings"
- [x] Expand a container with long labels — key/value should wrap rather than overflow