### PR TITLE
feat(ui): show empty state when no labeled containers are running

### DIFF
--- a/ui/src/components/ContainersTable.tsx
+++ b/ui/src/components/ContainersTable.tsx
@@ -96,6 +96,27 @@ export function ContainersTable({
       );
     }
 
+    if (!isLoading && containers.length === 0) {
+      return (
+        <Box
+          sx={{
+            flex: 1,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            py: 4,
+            border: '1px solid',
+            borderColor: 'divider',
+            borderRadius: 1,
+          }}
+        >
+          <Typography variant="body2" color="text.secondary">
+            No labeled containers are running.
+          </Typography>
+        </Box>
+      );
+    }
+
     return (
       <TableContainer component={Paper} variant="outlined" sx={{ flex: 1, overflow: 'auto' }}>
         <Table size="small" stickyHeader>


### PR DESCRIPTION
## Summary

- Shows "No labeled containers are running." when the container list is empty and not loading, replacing the empty table with a bordered placeholder
- Closes #24

## Test plan

- [x] Stop all containers with the `imds-proxy.enabled=true` label — empty state message should appear
- [x] Start a labeled container — table should replace the empty state