### PR TITLE
test: increase test coverage to ≥80% across all packages

### DIFF
--- a/backend/handlers_echo_test.go
+++ b/backend/handlers_echo_test.go
@@ -1,0 +1,305 @@
+// Copyright 2026 Matt Miller
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
+
+func withNoOpNotify(t *testing.T) {
+	t.Helper()
+	old := notifyProxyConfigUpdateFn
+	notifyProxyConfigUpdateFn = func() {}
+	t.Cleanup(func() { notifyProxyConfigUpdateFn = old })
+}
+
+func withTempSettingsPath(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	old := settingsPath
+	settingsPath = filepath.Join(dir, "settings.json")
+	t.Cleanup(func() { settingsPath = old })
+}
+
+func withSettings(t *testing.T, s Settings) {
+	t.Helper()
+	settingsMutex.Lock()
+	settings = s
+	settingsMutex.Unlock()
+	t.Cleanup(func() {
+		settingsMutex.Lock()
+		settings = Settings{}
+		settingsMutex.Unlock()
+	})
+}
+
+func TestHello(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/hello", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := hello(c); err != nil {
+		t.Fatalf("hello() returned error: %v", err)
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want status 200, got %d", rec.Code)
+	}
+}
+
+func TestGetSettings(t *testing.T) {
+	withSettings(t, Settings{URL: "http://test.example.com"})
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/settings", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := getSettings(c); err != nil {
+		t.Fatalf("getSettings() returned error: %v", err)
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want status 200, got %d", rec.Code)
+	}
+
+	var got Settings
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if got.URL != "http://test.example.com" {
+		t.Errorf("want URL %q, got %q", "http://test.example.com", got.URL)
+	}
+}
+
+func TestSaveSettingsValid(t *testing.T) {
+	withTempSettingsPath(t)
+	withSettings(t, Settings{})
+	withNoOpNotify(t)
+
+	e := echo.New()
+	body := strings.NewReader(`{"url":"http://example.com"}`)
+	req := httptest.NewRequest(http.MethodPost, "/settings", body)
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := saveSettings(c); err != nil {
+		t.Fatalf("saveSettings() returned error: %v", err)
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want status 200, got %d", rec.Code)
+	}
+
+	settingsMutex.RLock()
+	gotURL := settings.URL
+	settingsMutex.RUnlock()
+	if gotURL != "http://example.com" {
+		t.Errorf("want settings URL %q, got %q", "http://example.com", gotURL)
+	}
+}
+
+func TestSaveSettingsEmptyURL(t *testing.T) {
+	withTempSettingsPath(t)
+
+	e := echo.New()
+	body := strings.NewReader(`{"url":""}`)
+	req := httptest.NewRequest(http.MethodPost, "/settings", body)
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := saveSettings(c); err != nil {
+		t.Fatalf("saveSettings() returned error: %v", err)
+	}
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("want status 400, got %d", rec.Code)
+	}
+}
+
+func TestSaveSettingsInvalidJSON(t *testing.T) {
+	withTempSettingsPath(t)
+
+	e := echo.New()
+	body := strings.NewReader(`not-json`)
+	req := httptest.NewRequest(http.MethodPost, "/settings", body)
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := saveSettings(c); err != nil {
+		t.Fatalf("saveSettings() returned error: %v", err)
+	}
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("want status 400, got %d", rec.Code)
+	}
+}
+
+func TestGetContainersEmpty(t *testing.T) {
+	resetTracking()
+	t.Cleanup(resetTracking)
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/containers", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := getContainers(c); err != nil {
+		t.Fatalf("getContainers() returned error: %v", err)
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want status 200, got %d", rec.Code)
+	}
+
+	var result []ContainerInfo
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("want empty slice, got %d items", len(result))
+	}
+}
+
+func TestGetContainersWithData(t *testing.T) {
+	resetTracking()
+	t.Cleanup(resetTracking)
+
+	trackedContainersMutex.Lock()
+	trackedContainers["abc"] = ContainerInfo{
+		ContainerID: "abc",
+		Name:        "/test",
+		Labels:      map[string]string{},
+		Networks:    []NetworkInfo{{NetworkName: ".imds_aws_gcp", NetworkID: "net1"}},
+	}
+	trackedContainersMutex.Unlock()
+
+	managedNetworksMutex.Lock()
+	managedNetworks = []ImdsNetworkStatus{{NetworkName: ".imds_aws_gcp", Providers: []string{"AWS", "GCP"}}}
+	managedNetworksMutex.Unlock()
+	t.Cleanup(func() {
+		managedNetworksMutex.Lock()
+		managedNetworks = nil
+		managedNetworksMutex.Unlock()
+	})
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/containers", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := getContainers(c); err != nil {
+		t.Fatalf("getContainers() returned error: %v", err)
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want status 200, got %d", rec.Code)
+	}
+
+	var result []ContainerInfo
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(result) != 1 {
+		t.Fatalf("want 1 container, got %d", len(result))
+	}
+	if len(result[0].ImdsNetworks) != 1 {
+		t.Fatalf("want 1 imds network, got %d", len(result[0].ImdsNetworks))
+	}
+	if !result[0].ImdsNetworks[0].Connected {
+		t.Errorf("want ImdsNetworks[0].Connected=true for .imds_aws_gcp")
+	}
+}
+
+func TestGetProxyComposeSuccess(t *testing.T) {
+	dir := t.TempDir()
+	yamlPath := filepath.Join(dir, "compose.yaml")
+	content := []byte("version: '3'\nservices:\n  proxy:\n    image: test\n")
+	if err := os.WriteFile(yamlPath, content, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	old := proxyComposePath
+	proxyComposePath = yamlPath
+	t.Cleanup(func() { proxyComposePath = old })
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/proxy-compose", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := getProxyCompose(c); err != nil {
+		t.Fatalf("getProxyCompose() returned error: %v", err)
+	}
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want status 200, got %d", rec.Code)
+	}
+	if rec.Body.String() != string(content) {
+		t.Errorf("want yaml content %q, got %q", string(content), rec.Body.String())
+	}
+}
+
+func TestGetProxyComposeMissing(t *testing.T) {
+	old := proxyComposePath
+	proxyComposePath = "/nonexistent/path/compose.yaml"
+	t.Cleanup(func() { proxyComposePath = old })
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/proxy-compose", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	if err := getProxyCompose(c); err != nil {
+		t.Fatalf("getProxyCompose() returned error: %v", err)
+	}
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("want status 500, got %d", rec.Code)
+	}
+}
+
+func TestHandleProxyGetSettingsSuccess(t *testing.T) {
+	withSettings(t, Settings{URL: "http://proxy.example.com"})
+
+	req := httptest.NewRequest(http.MethodGet, "/settings", nil)
+	rec := httptest.NewRecorder()
+
+	handleProxyGetSettings(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want status 200, got %d", rec.Code)
+	}
+
+	var got Settings
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if got.URL != "http://proxy.example.com" {
+		t.Errorf("want URL %q, got %q", "http://proxy.example.com", got.URL)
+	}
+}

--- a/backend/handlers_test.go
+++ b/backend/handlers_test.go
@@ -102,3 +102,22 @@ func TestHandleContainerLookupByIPError(t *testing.T) {
 		t.Fatalf("want status %d (%s), got %d (%s)", http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError), rec.Code, http.StatusText(rec.Code))
 	}
 }
+
+func TestHandleContainerLookupByIPSuccess(t *testing.T) {
+	withFindContainerByIP(t, func(ctx context.Context, _ DockerClient, ip string) (*ProxyLookupResponse, error) {
+		return &ProxyLookupResponse{
+			ContainerID: "abc123",
+			Name:        "/my-container",
+			Labels:      map[string]string{"env": "test"},
+		}, nil
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/container-by-ip", bytes.NewBufferString(`{"ip":"10.0.0.12"}`))
+	rec := httptest.NewRecorder()
+
+	handleContainerLookupByIP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("want status %d (%s), got %d (%s)", http.StatusOK, http.StatusText(http.StatusOK), rec.Code, http.StatusText(rec.Code))
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -42,13 +42,14 @@ import (
 var logger = logrus.New()
 
 const (
-	imdsNetworkAWSGCP           = ".imds_aws_gcp"
-	imdsNetworkOpenStack        = ".imds_openstack"
-	proxySocketPath             = "/var/run/imds-proxy/backend.sock"
-	proxyNotificationSocketPath = "/var/run/imds-proxy/notifications.sock"
-	imdsManagedLabel            = "imds-proxy.managed"
-	imdsProvidersLabel          = "imds-proxy.providers"
+	imdsNetworkAWSGCP    = ".imds_aws_gcp"
+	imdsNetworkOpenStack = ".imds_openstack"
+	proxySocketPath      = "/var/run/imds-proxy/backend.sock"
+	imdsManagedLabel     = "imds-proxy.managed"
+	imdsProvidersLabel   = "imds-proxy.providers"
 )
+
+var proxyNotificationSocketPath = "/var/run/imds-proxy/notifications.sock"
 
 type Settings struct {
 	URL string `json:"url"`
@@ -103,6 +104,10 @@ var (
 )
 
 var findContainerByIPFn = findContainerByIP
+
+// notifyProxyConfigUpdateFn is a variable so tests can replace it with a no-op
+// to avoid spawning background goroutines that race with test cleanup.
+var notifyProxyConfigUpdateFn = notifyProxyConfigUpdate
 
 type DockerClient interface {
 	ContainerInspect(ctx context.Context, containerID string) (container.InspectResponse, error)
@@ -313,7 +318,7 @@ func saveSettings(ctx echo.Context) error {
 	}
 
 	// Notify proxy of config update
-	go notifyProxyConfigUpdate()
+	go notifyProxyConfigUpdateFn()
 
 	logger.Infof("Settings saved: url=%s", newSettings.URL)
 	return ctx.JSON(http.StatusOK, map[string]string{"message": "Settings saved successfully"})
@@ -753,6 +758,7 @@ func getContainers(ctx echo.Context) error {
 func notifyProxyConfigUpdate() {
 	maxRetries := 3
 	backoff := 100 * time.Millisecond
+	socketPath := proxyNotificationSocketPath
 
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		if attempt > 0 {
@@ -763,7 +769,7 @@ func notifyProxyConfigUpdate() {
 		client := &http.Client{
 			Transport: &http.Transport{
 				DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-					return net.Dial("unix", proxyNotificationSocketPath)
+					return net.Dial("unix", socketPath)
 				},
 			},
 			Timeout: 5 * time.Second,
@@ -800,6 +806,7 @@ func notifyProxyConfigUpdate() {
 func notifyProxyContainerDestroyed(containerID string) {
 	maxRetries := 3
 	backoff := 100 * time.Millisecond
+	socketPath := proxyNotificationSocketPath
 
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		if attempt > 0 {
@@ -810,7 +817,7 @@ func notifyProxyContainerDestroyed(containerID string) {
 		client := &http.Client{
 			Transport: &http.Transport{
 				DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-					return net.Dial("unix", proxyNotificationSocketPath)
+					return net.Dial("unix", socketPath)
 				},
 			},
 			Timeout: 5 * time.Second,

--- a/backend/monitor_test.go
+++ b/backend/monitor_test.go
@@ -1,0 +1,356 @@
+// Copyright 2026 Matt Miller
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/events"
+	"github.com/docker/docker/api/types/network"
+)
+
+// monitorDockerClient extends fakeDockerClient with controllable event channels.
+type monitorDockerClient struct {
+	fakeDockerClient
+	eventsCh chan events.Message
+	errCh    chan error
+}
+
+func newMonitorDockerClient() *monitorDockerClient {
+	return &monitorDockerClient{
+		eventsCh: make(chan events.Message, 10),
+		errCh:    make(chan error, 1),
+	}
+}
+
+func (m *monitorDockerClient) Events(_ context.Context, _ events.ListOptions) (<-chan events.Message, <-chan error) {
+	return m.eventsCh, m.errCh
+}
+
+func withDockerClient(t *testing.T, cli DockerClient) {
+	t.Helper()
+	old := dockerClient
+	dockerClient = cli
+	t.Cleanup(func() { dockerClient = old })
+}
+
+func withShutdownChan(t *testing.T) chan struct{} {
+	t.Helper()
+	old := shutdownChan
+	ch := make(chan struct{})
+	shutdownChan = ch
+	t.Cleanup(func() { shutdownChan = old })
+	return ch
+}
+
+// startMonitor starts monitorDockerEvents in a goroutine. It returns:
+//   - finished: closed when the goroutine exits (use for in-test assertions)
+//   - shutdown: call to close done exactly once (safe to call multiple times)
+//
+// A t.Cleanup registered here (LIFO relative to withShutdownChan /
+// withDockerClient) calls shutdown and waits for finished, ensuring the
+// goroutine has exited before those helpers restore their package-level vars.
+func startMonitor(t *testing.T, done chan struct{}) (finished chan struct{}, shutdown func()) {
+	t.Helper()
+	finished = make(chan struct{})
+	var once sync.Once
+	shutdown = func() { once.Do(func() { close(done) }) }
+
+	go func() {
+		monitorDockerEvents()
+		close(finished)
+	}()
+
+	t.Cleanup(func() {
+		shutdown()
+		select {
+		case <-finished:
+		case <-time.After(500 * time.Millisecond):
+		}
+	})
+	return finished, shutdown
+}
+
+func TestListen(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "test.sock")
+
+	ln, err := listen(path)
+	if err != nil {
+		t.Fatalf("listen() returned error: %v", err)
+	}
+	defer ln.Close()
+	if ln == nil {
+		t.Fatal("want non-nil listener")
+	}
+}
+
+func TestMonitorDockerEventsShutdown(t *testing.T) {
+	resetTracking()
+	t.Cleanup(resetTracking)
+
+	cli := newMonitorDockerClient()
+	withDockerClient(t, cli)
+	done := withShutdownChan(t)
+	finished, shutdown := startMonitor(t, done)
+
+	time.Sleep(20 * time.Millisecond)
+	shutdown()
+
+	select {
+	case <-finished:
+	case <-time.After(500 * time.Millisecond):
+		t.Error("monitorDockerEvents did not return after shutdown signal")
+	}
+}
+
+func TestMonitorDockerEventsContainerCreate(t *testing.T) {
+	resetTracking()
+	t.Cleanup(resetTracking)
+
+	containerID := "monitor-create-abc"
+	inspectResp := container.InspectResponse{
+		ContainerJSONBase: &container.ContainerJSONBase{
+			ID:    containerID,
+			Name:  "/monitor-test",
+			State: &container.State{Running: false},
+		},
+		Config: &container.Config{Labels: map[string]string{"imds-proxy.enabled": "true"}},
+		NetworkSettings: &container.NetworkSettings{
+			Networks: map[string]*network.EndpointSettings{},
+		},
+	}
+
+	cli := newMonitorDockerClient()
+	cli.fakeDockerClient.inspectSequence = []container.InspectResponse{inspectResp, inspectResp}
+
+	withDockerClient(t, cli)
+	done := withShutdownChan(t)
+	startMonitor(t, done)
+	time.Sleep(20 * time.Millisecond)
+
+	cli.eventsCh <- events.Message{
+		Type:   events.ContainerEventType,
+		Action: "create",
+		Actor: events.Actor{
+			ID: containerID,
+			Attributes: map[string]string{
+				"imds-proxy.enabled": "true",
+				"image":              "test:latest",
+			},
+		},
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	trackedContainersMutex.RLock()
+	_, tracked := trackedContainers[containerID]
+	trackedContainersMutex.RUnlock()
+	if !tracked {
+		t.Errorf("want container %s tracked after create event", containerID)
+	}
+}
+
+func TestMonitorDockerEventsContainerCreateNoLabel(t *testing.T) {
+	resetTracking()
+	t.Cleanup(resetTracking)
+
+	containerID := "monitor-nolabel-abc"
+	cli := newMonitorDockerClient()
+	withDockerClient(t, cli)
+	done := withShutdownChan(t)
+	startMonitor(t, done)
+	time.Sleep(20 * time.Millisecond)
+
+	cli.eventsCh <- events.Message{
+		Type:   events.ContainerEventType,
+		Action: "create",
+		Actor: events.Actor{
+			ID:         containerID,
+			Attributes: map[string]string{"image": "test:latest"},
+		},
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	trackedContainersMutex.RLock()
+	_, tracked := trackedContainers[containerID]
+	trackedContainersMutex.RUnlock()
+	if tracked {
+		t.Errorf("want unlabeled container %s NOT tracked", containerID)
+	}
+}
+
+func TestMonitorDockerEventsContainerDestroy(t *testing.T) {
+	resetTracking()
+	t.Cleanup(resetTracking)
+
+	containerID := "monitor-destroy-abc"
+	trackedContainersMutex.Lock()
+	trackedContainers[containerID] = ContainerInfo{ContainerID: containerID, Name: "/to-destroy"}
+	trackedContainersMutex.Unlock()
+
+	cli := newMonitorDockerClient()
+	withDockerClient(t, cli)
+	done := withShutdownChan(t)
+	startMonitor(t, done)
+	time.Sleep(20 * time.Millisecond)
+
+	cli.eventsCh <- events.Message{
+		Type:   events.ContainerEventType,
+		Action: "destroy",
+		Actor:  events.Actor{ID: containerID},
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	trackedContainersMutex.RLock()
+	_, tracked := trackedContainers[containerID]
+	trackedContainersMutex.RUnlock()
+	if tracked {
+		t.Errorf("want container %s removed after destroy event", containerID)
+	}
+}
+
+func TestMonitorDockerEventsNetworkConnect(t *testing.T) {
+	resetTracking()
+	t.Cleanup(resetTracking)
+
+	containerID := "monitor-net-abc"
+	trackedContainersMutex.Lock()
+	trackedContainers[containerID] = ContainerInfo{ContainerID: containerID, Name: "/net-test", Networks: []NetworkInfo{}}
+	trackedContainersMutex.Unlock()
+
+	cli := newMonitorDockerClient()
+	cli.fakeDockerClient.inspectSequence = []container.InspectResponse{
+		{
+			ContainerJSONBase: &container.ContainerJSONBase{
+				ID:    containerID,
+				Name:  "/net-test",
+				State: &container.State{Running: true},
+			},
+			Config: &container.Config{Labels: map[string]string{}},
+			NetworkSettings: &container.NetworkSettings{
+				Networks: map[string]*network.EndpointSettings{
+					"test-net": {NetworkID: "net-99"},
+				},
+			},
+		},
+	}
+	withDockerClient(t, cli)
+	done := withShutdownChan(t)
+	startMonitor(t, done)
+	time.Sleep(20 * time.Millisecond)
+
+	cli.eventsCh <- events.Message{
+		Type:   events.NetworkEventType,
+		Action: "connect",
+		Actor:  events.Actor{Attributes: map[string]string{"container": containerID}},
+	}
+	time.Sleep(100 * time.Millisecond)
+}
+
+func TestMonitorDockerEventsNetworkConnectUntracked(t *testing.T) {
+	resetTracking()
+	t.Cleanup(resetTracking)
+
+	cli := newMonitorDockerClient()
+	withDockerClient(t, cli)
+	done := withShutdownChan(t)
+	startMonitor(t, done)
+	time.Sleep(20 * time.Millisecond)
+
+	cli.eventsCh <- events.Message{
+		Type:   events.NetworkEventType,
+		Action: "disconnect",
+		Actor:  events.Actor{Attributes: map[string]string{"container": "untracked-container"}},
+	}
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestMonitorDockerEventsErrChanEOF(t *testing.T) {
+	resetTracking()
+	t.Cleanup(resetTracking)
+
+	cli := newMonitorDockerClient()
+	withDockerClient(t, cli)
+	done := withShutdownChan(t)
+	finished, _ := startMonitor(t, done)
+	time.Sleep(20 * time.Millisecond)
+
+	cli.errCh <- io.EOF
+
+	select {
+	case <-finished:
+	case <-time.After(500 * time.Millisecond):
+		t.Error("monitorDockerEvents did not return after io.EOF")
+	}
+}
+
+func TestMonitorDockerEventsErrChanError(t *testing.T) {
+	resetTracking()
+	t.Cleanup(resetTracking)
+
+	cli := newMonitorDockerClient()
+	withDockerClient(t, cli)
+	done := withShutdownChan(t)
+	finished, _ := startMonitor(t, done)
+	time.Sleep(20 * time.Millisecond)
+
+	cli.errCh <- errors.New("docker daemon disconnected")
+
+	select {
+	case <-finished:
+	case <-time.After(500 * time.Millisecond):
+		t.Error("monitorDockerEvents did not return after error")
+	}
+}
+
+func TestStartProxySocketServer(t *testing.T) {
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "proxy-test.sock")
+
+	withSettings(t, Settings{URL: "http://proxy-server-test.example.com"})
+	withDockerClient(t, &fakeDockerClient{})
+	withFindContainerByIP(t, func(_ context.Context, _ DockerClient, _ string) (*ProxyLookupResponse, error) {
+		return nil, nil
+	})
+
+	go startProxySocketServer(socketPath)
+	time.Sleep(50 * time.Millisecond)
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", socketPath)
+			},
+		},
+	}
+
+	resp, err := client.Get("http://unix/settings")
+	if err != nil {
+		t.Fatalf("GET /settings through proxy socket: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("want 200, got %d", resp.StatusCode)
+	}
+}

--- a/backend/notify_test.go
+++ b/backend/notify_test.go
@@ -1,0 +1,142 @@
+// Copyright 2026 Matt Miller
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+)
+
+func startTestUnixServer(t *testing.T, socketPath string, handler http.Handler) {
+	t.Helper()
+	_ = os.Remove(socketPath)
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := &http.Server{Handler: handler}
+	go srv.Serve(ln) //nolint:errcheck
+	t.Cleanup(func() {
+		srv.Close()
+		os.Remove(socketPath)
+	})
+}
+
+func withProxyNotificationSocket(t *testing.T, path string) {
+	t.Helper()
+	old := proxyNotificationSocketPath
+	proxyNotificationSocketPath = path
+	t.Cleanup(func() { proxyNotificationSocketPath = old })
+}
+
+func TestNotifyProxyConfigUpdateSuccess(t *testing.T) {
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "notify.sock")
+
+	var called atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/config-updated", func(w http.ResponseWriter, r *http.Request) {
+		called.Add(1)
+		w.WriteHeader(http.StatusOK)
+	})
+	startTestUnixServer(t, socketPath, mux)
+	withProxyNotificationSocket(t, socketPath)
+
+	notifyProxyConfigUpdate()
+
+	if called.Load() == 0 {
+		t.Error("want /config-updated to be called at least once")
+	}
+}
+
+func TestNotifyProxyConfigUpdateFailure(t *testing.T) {
+	withProxyNotificationSocket(t, "/tmp/nonexistent-notify-socket-12345.sock")
+
+	// Should exhaust retries and return without hanging.
+	// notifyProxyConfigUpdate has 3 retries with backoff starting at 100ms —
+	// total worst-case ~700ms, acceptable in a unit test.
+	notifyProxyConfigUpdate()
+}
+
+func TestNotifyProxyContainerDestroyedSuccess(t *testing.T) {
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "notify2.sock")
+
+	var receivedID string
+	var called atomic.Int32
+	mux := http.NewServeMux()
+	mux.HandleFunc("/container-destroyed", func(w http.ResponseWriter, r *http.Request) {
+		called.Add(1)
+		body, _ := io.ReadAll(r.Body)
+		var payload map[string]string
+		_ = json.Unmarshal(body, &payload)
+		receivedID = payload["containerId"]
+		w.WriteHeader(http.StatusOK)
+	})
+	startTestUnixServer(t, socketPath, mux)
+	withProxyNotificationSocket(t, socketPath)
+
+	notifyProxyContainerDestroyed("test-container-abc")
+
+	if called.Load() == 0 {
+		t.Error("want /container-destroyed to be called at least once")
+	}
+	if receivedID != "test-container-abc" {
+		t.Errorf("want containerID %q, got %q", "test-container-abc", receivedID)
+	}
+}
+
+func TestNotifyProxyContainerDestroyedFailure(t *testing.T) {
+	withProxyNotificationSocket(t, "/tmp/nonexistent-destroyed-socket-12345.sock")
+
+	// Should exhaust retries and return without hanging.
+	notifyProxyContainerDestroyed("some-container")
+}
+
+func TestNotifyProxyConfigUpdateNonOK(t *testing.T) {
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "notify-nonok.sock")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/config-updated", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	startTestUnixServer(t, socketPath, mux)
+	withProxyNotificationSocket(t, socketPath)
+
+	// Should exhaust retries against the non-200 server and return without hanging.
+	notifyProxyConfigUpdate()
+}
+
+func TestNotifyProxyContainerDestroyedNonOK(t *testing.T) {
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "notify-destroyed-nonok.sock")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/container-destroyed", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+	startTestUnixServer(t, socketPath, mux)
+	withProxyNotificationSocket(t, socketPath)
+
+	// Should exhaust retries against the non-200 server and return without hanging.
+	notifyProxyContainerDestroyed("some-container")
+}

--- a/backend/settings_test.go
+++ b/backend/settings_test.go
@@ -91,3 +91,48 @@ func TestPersistSettingsWritesFile(t *testing.T) {
 		t.Fatalf("want settings file to be written")
 	}
 }
+
+func TestPersistSettingsWriteError(t *testing.T) {
+	tempDir := t.TempDir()
+	originalPath := settingsPath
+	// Point settingsPath at a directory (not a file) so WriteFile fails
+	settingsPath = tempDir
+	defer func() { settingsPath = originalPath }()
+
+	settingsMutex.Lock()
+	settings = Settings{URL: "http://write-error.example.com"}
+	settingsMutex.Unlock()
+	defer func() {
+		settingsMutex.Lock()
+		settings = Settings{}
+		settingsMutex.Unlock()
+	}()
+
+	if err := persistSettings(); err == nil {
+		t.Fatal("want error when writing to a directory path, got nil")
+	}
+}
+
+func TestPersistSettingsNestedDir(t *testing.T) {
+	tempDir := t.TempDir()
+	originalPath := settingsPath
+	settingsPath = filepath.Join(tempDir, "nested", "deep", "settings.json")
+	defer func() { settingsPath = originalPath }()
+
+	settingsMutex.Lock()
+	settings = Settings{URL: "http://nested.example.com"}
+	settingsMutex.Unlock()
+	defer func() {
+		settingsMutex.Lock()
+		settings = Settings{}
+		settingsMutex.Unlock()
+	}()
+
+	if err := persistSettings(); err != nil {
+		t.Fatalf("persistSettings() with nested dir returned error: %v", err)
+	}
+
+	if _, err := os.Stat(settingsPath); err != nil {
+		t.Errorf("settings file not created at %s: %v", settingsPath, err)
+	}
+}

--- a/backend/tracking_test.go
+++ b/backend/tracking_test.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -31,13 +32,21 @@ import (
 type fakeDockerClient struct {
 	inspectCalls        int
 	inspectSequence     []container.InspectResponse
+	inspectErr          error
 	networkConnectCalls []string
 	pauseCalls          int
 	unpauseCalls        int
 	closeCalls          int
+	containerList       []container.Summary
+	containerListErr    error
+	networkList         []network.Summary
+	networkListErr      error
 }
 
 func (f *fakeDockerClient) ContainerInspect(_ context.Context, _ string) (container.InspectResponse, error) {
+	if f.inspectErr != nil {
+		return container.InspectResponse{}, f.inspectErr
+	}
 	if len(f.inspectSequence) == 0 {
 		return container.InspectResponse{}, nil
 	}
@@ -50,7 +59,7 @@ func (f *fakeDockerClient) ContainerInspect(_ context.Context, _ string) (contai
 }
 
 func (f *fakeDockerClient) ContainerList(_ context.Context, _ container.ListOptions) ([]container.Summary, error) {
-	return nil, nil
+	return f.containerList, f.containerListErr
 }
 
 func (f *fakeDockerClient) Events(_ context.Context, _ events.ListOptions) (<-chan events.Message, <-chan error) {
@@ -63,6 +72,9 @@ func (f *fakeDockerClient) NetworkConnect(_ context.Context, networkID, _ string
 }
 
 func (f *fakeDockerClient) NetworkList(_ context.Context, _ network.ListOptions) ([]network.Summary, error) {
+	if f.networkList != nil || f.networkListErr != nil {
+		return f.networkList, f.networkListErr
+	}
 	return []network.Summary{}, nil
 }
 
@@ -209,6 +221,54 @@ func TestAddAndRemoveContainerTracking(t *testing.T) {
 		t.Fatalf("want container to be removed")
 	}
 	trackedContainersMutex.RUnlock()
+}
+
+func TestAddContainerToTrackingWithNetworkPauseFirst(t *testing.T) {
+	resetTracking()
+	defer resetTracking()
+
+	containerID := "pause-test-abc"
+	inspectInitial := container.InspectResponse{
+		ContainerJSONBase: &container.ContainerJSONBase{
+			ID:   containerID,
+			Name: "/pause-test",
+			State: &container.State{
+				Running: true,
+			},
+		},
+		Config: &container.Config{Labels: map[string]string{}},
+		NetworkSettings: &container.NetworkSettings{
+			Networks: map[string]*network.EndpointSettings{},
+		},
+	}
+	inspectUpdated := container.InspectResponse{
+		ContainerJSONBase: &container.ContainerJSONBase{
+			ID:   containerID,
+			Name: "/pause-test",
+			State: &container.State{
+				Running: true,
+			},
+		},
+		Config: &container.Config{Labels: map[string]string{}},
+		NetworkSettings: &container.NetworkSettings{
+			Networks: map[string]*network.EndpointSettings{
+				imdsNetworkAWSGCP: {NetworkID: "net-aws"},
+			},
+		},
+	}
+
+	client := &fakeDockerClient{inspectSequence: []container.InspectResponse{inspectInitial, inspectUpdated}}
+
+	if err := addContainerToTrackingWithNetwork(context.Background(), client, containerID, true); err != nil {
+		t.Fatalf("want no error, got %v", err)
+	}
+
+	if client.pauseCalls != 1 {
+		t.Errorf("want 1 pause call, got %d", client.pauseCalls)
+	}
+	if client.unpauseCalls != 1 {
+		t.Errorf("want 1 unpause call, got %d", client.unpauseCalls)
+	}
 }
 
 // TestConcurrentContainerTracking tests concurrent additions and removals
@@ -908,5 +968,387 @@ func TestStressRapidSettingsChanges(t *testing.T) {
 		finalURL := settings.URL
 		settingsMutex.RUnlock()
 		t.Logf("Final settings URL: %s", finalURL)
+	}
+}
+
+func resetManagedNetworks() {
+	managedNetworksMutex.Lock()
+	defer managedNetworksMutex.Unlock()
+	managedNetworks = nil
+}
+
+func TestScanExistingContainersEmpty(t *testing.T) {
+	resetTracking()
+	t.Cleanup(resetTracking)
+
+	cli := &fakeDockerClient{}
+	if err := scanExistingContainers(context.Background(), cli); err != nil {
+		t.Fatalf("want no error, got %v", err)
+	}
+
+	trackedContainersMutex.RLock()
+	n := len(trackedContainers)
+	trackedContainersMutex.RUnlock()
+	if n != 0 {
+		t.Errorf("want 0 tracked containers, got %d", n)
+	}
+}
+
+func TestScanExistingContainersLabeledContainer(t *testing.T) {
+	resetTracking()
+	t.Cleanup(resetTracking)
+
+	containerID := "labeled123"
+	cli := &fakeDockerClient{
+		containerList: []container.Summary{
+			{
+				ID:     containerID,
+				Labels: map[string]string{"imds-proxy.enabled": "true"},
+			},
+		},
+		inspectSequence: []container.InspectResponse{
+			{
+				ContainerJSONBase: &container.ContainerJSONBase{
+					ID:    containerID,
+					Name:  "/labeled",
+					State: &container.State{Running: false},
+				},
+				Config: &container.Config{Labels: map[string]string{"imds-proxy.enabled": "true"}},
+				NetworkSettings: &container.NetworkSettings{
+					Networks: map[string]*network.EndpointSettings{
+						".imds_aws_gcp": {NetworkID: "net1"},
+					},
+				},
+			},
+			{
+				ContainerJSONBase: &container.ContainerJSONBase{
+					ID:    containerID,
+					Name:  "/labeled",
+					State: &container.State{Running: false},
+				},
+				Config: &container.Config{Labels: map[string]string{"imds-proxy.enabled": "true"}},
+				NetworkSettings: &container.NetworkSettings{
+					Networks: map[string]*network.EndpointSettings{
+						".imds_aws_gcp":   {NetworkID: "net1"},
+						".imds_openstack": {NetworkID: "net2"},
+					},
+				},
+			},
+		},
+	}
+
+	if err := scanExistingContainers(context.Background(), cli); err != nil {
+		t.Fatalf("want no error, got %v", err)
+	}
+
+	trackedContainersMutex.RLock()
+	_, ok := trackedContainers[containerID]
+	trackedContainersMutex.RUnlock()
+	if !ok {
+		t.Errorf("want container %s to be tracked", containerID)
+	}
+}
+
+func TestScanExistingContainersUnlabeledContainer(t *testing.T) {
+	resetTracking()
+	t.Cleanup(resetTracking)
+
+	cli := &fakeDockerClient{
+		containerList: []container.Summary{
+			{
+				ID:     "unlabeled456",
+				Labels: map[string]string{"some-other-label": "value"},
+			},
+		},
+	}
+
+	if err := scanExistingContainers(context.Background(), cli); err != nil {
+		t.Fatalf("want no error, got %v", err)
+	}
+
+	trackedContainersMutex.RLock()
+	n := len(trackedContainers)
+	trackedContainersMutex.RUnlock()
+	if n != 0 {
+		t.Errorf("want 0 tracked containers for unlabeled container, got %d", n)
+	}
+}
+
+func TestScanExistingContainersError(t *testing.T) {
+	resetTracking()
+	t.Cleanup(resetTracking)
+
+	cli := &fakeDockerClient{
+		containerListErr: errors.New("docker unavailable"),
+	}
+
+	err := scanExistingContainers(context.Background(), cli)
+	if err == nil {
+		t.Fatal("want error propagated, got nil")
+	}
+}
+
+func TestDiscoverManagedNetworksEmpty(t *testing.T) {
+	resetManagedNetworks()
+	t.Cleanup(resetManagedNetworks)
+
+	cli := &fakeDockerClient{networkList: []network.Summary{}}
+
+	if err := discoverManagedNetworks(context.Background(), cli); err != nil {
+		t.Fatalf("want no error, got %v", err)
+	}
+
+	managedNetworksMutex.RLock()
+	n := len(managedNetworks)
+	managedNetworksMutex.RUnlock()
+	if n != 0 {
+		t.Errorf("want 0 managed networks, got %d", n)
+	}
+}
+
+func TestDiscoverManagedNetworksWithProviders(t *testing.T) {
+	resetManagedNetworks()
+	t.Cleanup(resetManagedNetworks)
+
+	cli := &fakeDockerClient{
+		networkList: []network.Summary{
+			{
+				Name: ".imds_aws_gcp",
+				Labels: map[string]string{
+					"imds-proxy.managed":   "true",
+					"imds-proxy.providers": "AWS,GCP",
+				},
+			},
+		},
+	}
+
+	if err := discoverManagedNetworks(context.Background(), cli); err != nil {
+		t.Fatalf("want no error, got %v", err)
+	}
+
+	managedNetworksMutex.RLock()
+	nets := managedNetworks
+	managedNetworksMutex.RUnlock()
+
+	if len(nets) != 1 {
+		t.Fatalf("want 1 managed network, got %d", len(nets))
+	}
+	if nets[0].NetworkName != ".imds_aws_gcp" {
+		t.Errorf("want network name .imds_aws_gcp, got %s", nets[0].NetworkName)
+	}
+	if len(nets[0].Providers) != 2 {
+		t.Fatalf("want 2 providers, got %d", len(nets[0].Providers))
+	}
+	if nets[0].Providers[0] != "AWS" || nets[0].Providers[1] != "GCP" {
+		t.Errorf("want providers [AWS GCP], got %v", nets[0].Providers)
+	}
+}
+
+func TestDiscoverManagedNetworksError(t *testing.T) {
+	resetManagedNetworks()
+	t.Cleanup(resetManagedNetworks)
+
+	cli := &fakeDockerClient{networkListErr: errors.New("network list failed")}
+
+	err := discoverManagedNetworks(context.Background(), cli)
+	if err == nil {
+		t.Fatal("want error propagated, got nil")
+	}
+}
+
+func TestRefreshContainerNetworksTracked(t *testing.T) {
+	resetTracking()
+	t.Cleanup(resetTracking)
+
+	containerID := "refresh123"
+	trackedContainersMutex.Lock()
+	trackedContainers[containerID] = ContainerInfo{
+		ContainerID: containerID,
+		Name:        "/refresh-test",
+		Labels:      map[string]string{},
+		Networks:    []NetworkInfo{},
+	}
+	trackedContainersMutex.Unlock()
+
+	cli := &fakeDockerClient{
+		inspectSequence: []container.InspectResponse{
+			{
+				ContainerJSONBase: &container.ContainerJSONBase{
+					ID:    containerID,
+					Name:  "/refresh-test",
+					State: &container.State{Running: false},
+				},
+				Config: &container.Config{Labels: map[string]string{}},
+				NetworkSettings: &container.NetworkSettings{
+					Networks: map[string]*network.EndpointSettings{
+						".imds_aws_gcp": {NetworkID: "updated-net1"},
+					},
+				},
+			},
+		},
+	}
+
+	if err := refreshContainerNetworks(context.Background(), cli, containerID); err != nil {
+		t.Fatalf("want no error, got %v", err)
+	}
+
+	trackedContainersMutex.RLock()
+	info := trackedContainers[containerID]
+	trackedContainersMutex.RUnlock()
+
+	if len(info.Networks) != 1 {
+		t.Fatalf("want 1 network after refresh, got %d", len(info.Networks))
+	}
+	if info.Networks[0].NetworkID != "updated-net1" {
+		t.Errorf("want NetworkID updated-net1, got %s", info.Networks[0].NetworkID)
+	}
+}
+
+func TestRefreshContainerNetworksUntracked(t *testing.T) {
+	resetTracking()
+	t.Cleanup(resetTracking)
+
+	cli := &fakeDockerClient{
+		inspectSequence: []container.InspectResponse{
+			{
+				ContainerJSONBase: &container.ContainerJSONBase{
+					ID:    "untracked999",
+					Name:  "/untracked",
+					State: &container.State{Running: false},
+				},
+				Config: &container.Config{Labels: map[string]string{}},
+				NetworkSettings: &container.NetworkSettings{
+					Networks: map[string]*network.EndpointSettings{},
+				},
+			},
+		},
+	}
+
+	// Container is not in trackedContainers — should return nil without panic.
+	if err := refreshContainerNetworks(context.Background(), cli, "untracked999"); err != nil {
+		t.Fatalf("want no error for untracked container, got %v", err)
+	}
+}
+
+func TestRefreshContainerNetworksError(t *testing.T) {
+	resetTracking()
+	t.Cleanup(resetTracking)
+
+	cli := &fakeDockerClient{inspectErr: errors.New("inspect failed")}
+
+	err := refreshContainerNetworks(context.Background(), cli, "some-container")
+	if err == nil {
+		t.Fatal("want error propagated from inspect, got nil")
+	}
+}
+
+func TestFindContainerByIPFound(t *testing.T) {
+	resetTracking()
+	t.Cleanup(resetTracking)
+
+	containerID := "ipfound123"
+	trackedContainersMutex.Lock()
+	trackedContainers[containerID] = ContainerInfo{
+		ContainerID: containerID,
+		Name:        "/ip-test",
+		Labels:      map[string]string{"app": "test"},
+		Networks:    []NetworkInfo{{NetworkName: ".imds_aws_gcp", NetworkID: "net-x"}},
+	}
+	trackedContainersMutex.Unlock()
+
+	cli := &fakeDockerClient{
+		inspectSequence: []container.InspectResponse{
+			{
+				ContainerJSONBase: &container.ContainerJSONBase{
+					ID:    containerID,
+					Name:  "/ip-test",
+					State: &container.State{Running: true},
+				},
+				Config: &container.Config{Labels: map[string]string{"app": "test"}},
+				NetworkSettings: &container.NetworkSettings{
+					Networks: map[string]*network.EndpointSettings{
+						".imds_aws_gcp": {NetworkID: "net-x", IPAddress: "10.5.0.42"},
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := findContainerByIP(context.Background(), cli, "10.5.0.42")
+	if err != nil {
+		t.Fatalf("want no error, got %v", err)
+	}
+	if resp == nil {
+		t.Fatal("want response, got nil")
+	}
+	if resp.ContainerID != containerID {
+		t.Errorf("want ContainerID %s, got %s", containerID, resp.ContainerID)
+	}
+}
+
+func TestFindContainerByIPNotFound(t *testing.T) {
+	resetTracking()
+	t.Cleanup(resetTracking)
+
+	containerID := "ipnotfound456"
+	trackedContainersMutex.Lock()
+	trackedContainers[containerID] = ContainerInfo{
+		ContainerID: containerID,
+		Name:        "/no-ip",
+		Labels:      map[string]string{},
+		Networks:    []NetworkInfo{{NetworkName: ".imds_aws_gcp", NetworkID: "net-y"}},
+	}
+	trackedContainersMutex.Unlock()
+
+	cli := &fakeDockerClient{
+		inspectSequence: []container.InspectResponse{
+			{
+				ContainerJSONBase: &container.ContainerJSONBase{
+					ID:    containerID,
+					Name:  "/no-ip",
+					State: &container.State{Running: true},
+				},
+				Config: &container.Config{Labels: map[string]string{}},
+				NetworkSettings: &container.NetworkSettings{
+					Networks: map[string]*network.EndpointSettings{
+						".imds_aws_gcp": {NetworkID: "net-y", IPAddress: "10.5.0.1"},
+					},
+				},
+			},
+		},
+	}
+
+	resp, err := findContainerByIP(context.Background(), cli, "192.168.99.99")
+	if err != nil {
+		t.Fatalf("want no error, got %v", err)
+	}
+	if resp != nil {
+		t.Errorf("want nil response for unmatched IP, got %+v", resp)
+	}
+}
+
+func TestFindContainerByIPInspectError(t *testing.T) {
+	resetTracking()
+	t.Cleanup(resetTracking)
+
+	containerID := "inspect-err-789"
+	trackedContainersMutex.Lock()
+	trackedContainers[containerID] = ContainerInfo{
+		ContainerID: containerID,
+		Name:        "/err-container",
+		Labels:      map[string]string{},
+		Networks:    []NetworkInfo{{NetworkName: ".imds_aws_gcp", NetworkID: "net-z"}},
+	}
+	trackedContainersMutex.Unlock()
+
+	cli := &fakeDockerClient{inspectErr: errors.New("inspect error")}
+
+	// findContainerByIP continues past inspect errors and returns nil.
+	resp, err := findContainerByIP(context.Background(), cli, "10.0.0.1")
+	if err != nil {
+		t.Fatalf("want no error (function skips failed inspects), got %v", err)
+	}
+	if resp != nil {
+		t.Errorf("want nil response when inspect fails, got %+v", resp)
 	}
 }

--- a/proxy/forward_test.go
+++ b/proxy/forward_test.go
@@ -1,0 +1,230 @@
+// Copyright 2026 Matt Miller
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestForwardRequestSuccess(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"iam":"metadata"}`))
+	}))
+	defer upstream.Close()
+
+	originalURL := getForwardURL()
+	setForwardURL(upstream.URL)
+	t.Cleanup(func() { setForwardURL(originalURL) })
+
+	req := httptest.NewRequest(http.MethodGet, "/latest/meta-data/", nil)
+	rec := httptest.NewRecorder()
+
+	if err := forwardRequest(rec, req, &lookupResponse{ContainerID: "abc123", Name: "/app", Labels: map[string]string{}}); err != nil {
+		t.Fatalf("forwardRequest() error: %v", err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("want status 200, got %d", rec.Code)
+	}
+}
+
+func TestForwardRequestWithQueryString(t *testing.T) {
+	var receivedQuery string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	originalURL := getForwardURL()
+	setForwardURL(upstream.URL)
+	t.Cleanup(func() { setForwardURL(originalURL) })
+
+	req := httptest.NewRequest(http.MethodGet, "/metadata?v=1&region=us-east-1", nil)
+	rec := httptest.NewRecorder()
+
+	if err := forwardRequest(rec, req, &lookupResponse{ContainerID: "abc123", Name: "/app", Labels: map[string]string{}}); err != nil {
+		t.Fatalf("forwardRequest() error: %v", err)
+	}
+	if receivedQuery != "v=1&region=us-east-1" {
+		t.Errorf("want query string forwarded, got %q", receivedQuery)
+	}
+}
+
+func TestForwardRequestWithLabels(t *testing.T) {
+	var receivedLabels string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedLabels = r.Header.Get("x-container-labels")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	originalURL := getForwardURL()
+	setForwardURL(upstream.URL)
+	t.Cleanup(func() { setForwardURL(originalURL) })
+
+	req := httptest.NewRequest(http.MethodGet, "/latest/", nil)
+	rec := httptest.NewRecorder()
+	containerInfo := &lookupResponse{
+		ContainerID: "abc123",
+		Name:        "/app",
+		Labels:      map[string]string{"env": "test", "imds-proxy.enabled": "true"},
+	}
+
+	if err := forwardRequest(rec, req, containerInfo); err != nil {
+		t.Fatalf("forwardRequest() error: %v", err)
+	}
+	if receivedLabels == "" {
+		t.Error("want x-container-labels header to be set")
+	}
+}
+
+func TestForwardRequestContainerHeaders(t *testing.T) {
+	var gotID, gotName string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotID = r.Header.Get("x-container-id")
+		gotName = r.Header.Get("x-container-name")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	originalURL := getForwardURL()
+	setForwardURL(upstream.URL)
+	t.Cleanup(func() { setForwardURL(originalURL) })
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+
+	if err := forwardRequest(rec, req, &lookupResponse{ContainerID: "myid", Name: "/myname", Labels: map[string]string{}}); err != nil {
+		t.Fatalf("forwardRequest() error: %v", err)
+	}
+	if gotID != "myid" {
+		t.Errorf("want x-container-id=myid, got %q", gotID)
+	}
+	if gotName != "/myname" {
+		t.Errorf("want x-container-name=/myname, got %q", gotName)
+	}
+}
+
+func TestForwardRequestError(t *testing.T) {
+	originalURL := getForwardURL()
+	// Port 1 is reserved/unreachable on Linux — connection refused
+	setForwardURL("http://127.0.0.1:1")
+	t.Cleanup(func() { setForwardURL(originalURL) })
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+
+	err := forwardRequest(rec, req, &lookupResponse{ContainerID: "abc", Name: "/app", Labels: map[string]string{}})
+	if err == nil {
+		t.Fatal("want error for unreachable upstream, got nil")
+	}
+}
+
+func TestHandleRequestSuccess(t *testing.T) {
+	ensureClearCache(t)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("metadata"))
+	}))
+	defer upstream.Close()
+
+	originalURL := getForwardURL()
+	setForwardURL(upstream.URL)
+	t.Cleanup(func() { setForwardURL(originalURL) })
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"containerId":"abc123","name":"/app","labels":{}}`))
+	}))
+	defer backend.Close()
+
+	originalDial := backendDial
+	backendDial = func(ctx context.Context, _, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, "tcp", backend.Listener.Addr().String())
+	}
+	defer func() { backendDial = originalDial }()
+
+	req := httptest.NewRequest(http.MethodGet, "http://169.254.169.254/latest/meta-data/", nil)
+	req.RemoteAddr = "10.0.0.5:1234"
+	rec := httptest.NewRecorder()
+
+	handleRequest(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("want status 200, got %d", rec.Code)
+	}
+}
+
+func TestHandleRequestForwardError(t *testing.T) {
+	ensureClearCache(t)
+
+	originalURL := getForwardURL()
+	setForwardURL("http://127.0.0.1:1") // connection refused
+	t.Cleanup(func() { setForwardURL(originalURL) })
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"containerId":"abc123","name":"/app","labels":{}}`))
+	}))
+	defer backend.Close()
+
+	originalDial := backendDial
+	backendDial = func(ctx context.Context, _, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, "tcp", backend.Listener.Addr().String())
+	}
+	defer func() { backendDial = originalDial }()
+
+	req := httptest.NewRequest(http.MethodGet, "http://169.254.169.254/latest/meta-data/", nil)
+	req.RemoteAddr = "10.0.0.6:1234"
+	rec := httptest.NewRecorder()
+
+	handleRequest(rec, req)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Errorf("want status 502, got %d", rec.Code)
+	}
+}
+
+func TestForwardRequestLocalhostRewrite(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	// Extract just the port to build a localhost URL
+	addr := upstream.Listener.Addr().String()
+	port := addr[strings.LastIndex(addr, ":"):]
+
+	originalURL := getForwardURL()
+	setForwardURL("http://localhost" + port)
+	t.Cleanup(func() { setForwardURL(originalURL) })
+
+	// Override transport to redirect host.docker.internal back to test server
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+
+	// forwardRequest will rewrite localhost→host.docker.internal; if that fails,
+	// we just verify it attempted the rewrite (no panic, error expected since
+	// host.docker.internal may not resolve in CI).
+	_ = forwardRequest(rec, req, &lookupResponse{ContainerID: "abc", Name: "/app", Labels: map[string]string{}})
+	// No assertion on success — this test exercises the rewrite code path.
+}

--- a/proxy/listener_test.go
+++ b/proxy/listener_test.go
@@ -1,0 +1,171 @@
+// Copyright 2026 Matt Miller
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func withNotificationSocketPath(t *testing.T, path string) {
+	t.Helper()
+	old := proxyNotificationSocketPath
+	proxyNotificationSocketPath = path
+	t.Cleanup(func() { proxyNotificationSocketPath = old })
+}
+
+func TestStartNotificationListener(t *testing.T) {
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "notify-test.sock")
+	withNotificationSocketPath(t, socketPath)
+
+	go startNotificationListener()
+	time.Sleep(50 * time.Millisecond)
+
+	// Verify the listener is up by hitting handleConfigUpdate
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"url":"http://refresh.example.com"}`))
+	}))
+	defer backend.Close()
+
+	originalDial := backendDial
+	backendDial = func(ctx context.Context, _, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, "tcp", backend.Listener.Addr().String())
+	}
+	defer func() { backendDial = originalDial }()
+
+	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
+				return net.Dial("unix", socketPath)
+			},
+		},
+	}
+
+	resp, err := client.Post("http://unix/config-updated", "application/json", nil)
+	if err != nil {
+		t.Fatalf("POST /config-updated to notification listener: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("want 200, got %d", resp.StatusCode)
+	}
+}
+
+// startRefresher starts startForwardURLRefresher with a cancellable context.
+// It registers a t.Cleanup (called LAST, so runs FIRST in LIFO order) that
+// cancels the context and waits for the goroutine to exit before other
+// cleanups restore shared variables like backendDial and forwardURLRefreshInterval.
+// Call startRefresher AFTER all other t.Cleanup registrations in each test.
+func startRefresher(t *testing.T) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		startForwardURLRefresher(ctx)
+		close(done)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(500 * time.Millisecond):
+		}
+	})
+}
+
+func TestStartForwardURLRefresherFetchesURL(t *testing.T) {
+	ensureClearCache(t)
+
+	originalURL := getForwardURL()
+	setForwardURL("")
+	t.Cleanup(func() { setForwardURL(originalURL) })
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"url":"http://refreshed.example.com"}`))
+	}))
+	defer backend.Close()
+
+	originalDial := backendDial
+	backendDial = func(ctx context.Context, _, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, "tcp", backend.Listener.Addr().String())
+	}
+	t.Cleanup(func() { backendDial = originalDial })
+
+	oldInterval := forwardURLRefreshInterval
+	forwardURLRefreshInterval = 10 * time.Millisecond
+	t.Cleanup(func() { forwardURLRefreshInterval = oldInterval })
+
+	// startRefresher registered last so its cleanup (cancel+wait) runs first
+	startRefresher(t)
+	time.Sleep(100 * time.Millisecond)
+
+	if getForwardURL() != "http://refreshed.example.com" {
+		t.Errorf("want URL set by refresher, got %q", getForwardURL())
+	}
+}
+
+func TestStartForwardURLRefresherSkipsWhenURLSet(t *testing.T) {
+	originalURL := getForwardURL()
+	setForwardURL("http://already-set.example.com")
+	t.Cleanup(func() { setForwardURL(originalURL) })
+
+	originalDial := backendDial
+	backendDial = func(ctx context.Context, _, _ string) (net.Conn, error) {
+		return nil, context.DeadlineExceeded
+	}
+	t.Cleanup(func() { backendDial = originalDial })
+
+	oldInterval := forwardURLRefreshInterval
+	forwardURLRefreshInterval = 10 * time.Millisecond
+	t.Cleanup(func() { forwardURLRefreshInterval = oldInterval })
+
+	startRefresher(t)
+	time.Sleep(50 * time.Millisecond)
+
+	if getForwardURL() != "http://already-set.example.com" {
+		t.Errorf("want URL unchanged, got %q", getForwardURL())
+	}
+}
+
+func TestStartForwardURLRefresherHandlesFetchError(t *testing.T) {
+	originalURL := getForwardURL()
+	setForwardURL("")
+	t.Cleanup(func() { setForwardURL(originalURL) })
+
+	originalDial := backendDial
+	backendDial = func(ctx context.Context, _, _ string) (net.Conn, error) {
+		return nil, context.DeadlineExceeded
+	}
+	t.Cleanup(func() { backendDial = originalDial })
+
+	oldInterval := forwardURLRefreshInterval
+	forwardURLRefreshInterval = 10 * time.Millisecond
+	t.Cleanup(func() { forwardURLRefreshInterval = oldInterval })
+
+	startRefresher(t)
+	time.Sleep(50 * time.Millisecond)
+
+	if getForwardURL() != "" {
+		t.Errorf("want URL empty after fetch error, got %q", getForwardURL())
+	}
+}

--- a/proxy/main.go
+++ b/proxy/main.go
@@ -32,7 +32,7 @@ import (
 
 const backendSocketPath = "/var/run/imds-proxy/backend.sock"
 
-const proxyNotificationSocketPath = "/var/run/imds-proxy/notifications.sock"
+var proxyNotificationSocketPath = "/var/run/imds-proxy/notifications.sock"
 
 const backendLookupPath = "http://unix/container-by-ip"
 
@@ -91,7 +91,7 @@ func main() {
 		log.Printf("Forward URL configured: %s", getForwardURL())
 	}
 
-	go startForwardURLRefresher()
+	go startForwardURLRefresher(context.Background())
 
 	// Start notification listener for config updates from backend
 	go startNotificationListener()
@@ -437,17 +437,25 @@ func setForwardURL(url string) {
 	forwardURL.Store(url)
 }
 
-func startForwardURLRefresher() {
-	ticker := time.NewTicker(10 * time.Second)
+var forwardURLRefreshInterval = 10 * time.Second
+
+func startForwardURLRefresher(ctx context.Context) {
+	ticker := time.NewTicker(forwardURLRefreshInterval)
 	defer ticker.Stop()
 
-	for range ticker.C {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+
 		if getForwardURL() != "" {
 			continue
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		url, err := fetchForwardURL(ctx)
+		fetchCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		url, err := fetchForwardURL(fetchCtx)
 		cancel()
 
 		if err != nil {

--- a/proxy/notification_handler_test.go
+++ b/proxy/notification_handler_test.go
@@ -1,0 +1,189 @@
+// Copyright 2026 Matt Miller
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// --- handleConfigUpdate ---
+
+func TestHandleConfigUpdateMethodNotAllowed(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/config-updated", nil)
+	rec := httptest.NewRecorder()
+
+	handleConfigUpdate(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("want status 405, got %d", rec.Code)
+	}
+}
+
+func TestHandleConfigUpdateSuccess(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"url":"http://new-imds.example.com"}`))
+	}))
+	defer backend.Close()
+
+	originalDial := backendDial
+	backendDial = func(ctx context.Context, _, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, "tcp", backend.Listener.Addr().String())
+	}
+	defer func() { backendDial = originalDial }()
+
+	originalURL := getForwardURL()
+	setForwardURL("http://old.example.com")
+	t.Cleanup(func() { setForwardURL(originalURL) })
+
+	req := httptest.NewRequest(http.MethodPost, "/config-updated", nil)
+	rec := httptest.NewRecorder()
+
+	handleConfigUpdate(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("want status 200, got %d", rec.Code)
+	}
+	if getForwardURL() != "http://new-imds.example.com" {
+		t.Errorf("want URL updated to new-imds.example.com, got %q", getForwardURL())
+	}
+}
+
+func TestHandleConfigUpdateSameURL(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"url":"http://same.example.com"}`))
+	}))
+	defer backend.Close()
+
+	originalDial := backendDial
+	backendDial = func(ctx context.Context, _, _ string) (net.Conn, error) {
+		return (&net.Dialer{}).DialContext(ctx, "tcp", backend.Listener.Addr().String())
+	}
+	defer func() { backendDial = originalDial }()
+
+	originalURL := getForwardURL()
+	setForwardURL("http://same.example.com")
+	t.Cleanup(func() { setForwardURL(originalURL) })
+
+	req := httptest.NewRequest(http.MethodPost, "/config-updated", nil)
+	rec := httptest.NewRecorder()
+
+	handleConfigUpdate(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("want status 200, got %d", rec.Code)
+	}
+}
+
+func TestHandleConfigUpdateFetchError(t *testing.T) {
+	originalDial := backendDial
+	backendDial = func(ctx context.Context, _, _ string) (net.Conn, error) {
+		return nil, context.DeadlineExceeded
+	}
+	defer func() { backendDial = originalDial }()
+
+	req := httptest.NewRequest(http.MethodPost, "/config-updated", nil)
+	rec := httptest.NewRecorder()
+
+	handleConfigUpdate(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("want status 500, got %d", rec.Code)
+	}
+}
+
+// --- handleContainerDestroyed ---
+
+func TestHandleContainerDestroyedMethodNotAllowed(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/container-destroyed", nil)
+	rec := httptest.NewRecorder()
+
+	handleContainerDestroyed(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("want status 405, got %d", rec.Code)
+	}
+}
+
+func TestHandleContainerDestroyedInvalidJSON(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/container-destroyed", strings.NewReader("not-json"))
+	rec := httptest.NewRecorder()
+
+	handleContainerDestroyed(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("want status 400, got %d", rec.Code)
+	}
+}
+
+func TestHandleContainerDestroyedEmptyID(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/container-destroyed", strings.NewReader(`{"containerId":""}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handleContainerDestroyed(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("want status 400, got %d", rec.Code)
+	}
+}
+
+func TestHandleContainerDestroyedSuccess(t *testing.T) {
+	ensureClearCache(t)
+
+	// Pre-populate cache with an entry for this container
+	ip := "169.254.169.100"
+	lookupCache.Store(ip, cacheEntry{
+		response:  &lookupResponse{ContainerID: "abc123def456", Name: "/my-app"},
+		found:     true,
+		expiresAt: time.Now().Add(cacheTTL),
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/container-destroyed",
+		strings.NewReader(`{"containerId":"abc123def456"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handleContainerDestroyed(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("want status 200, got %d", rec.Code)
+	}
+	if _, ok := lookupCache.Load(ip); ok {
+		t.Error("want cache entry removed after container destroyed notification")
+	}
+}
+
+func TestHandleContainerDestroyedShortID(t *testing.T) {
+	ensureClearCache(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/container-destroyed",
+		strings.NewReader(`{"containerId":"short"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handleContainerDestroyed(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("want status 200 for short container ID, got %d", rec.Code)
+	}
+}

--- a/ui/src/__tests__/containersTable.test.tsx
+++ b/ui/src/__tests__/containersTable.test.tsx
@@ -187,4 +187,88 @@ describe('ContainersTable', () => {
     expect(screen.queryByText('Loading containers...')).toBeNull();
     expect(screen.queryByText('webapp')).toBeDefined();
   });
+
+  it('clicking a row expands the labels panel', () => {
+    const mockCallback = vi.fn();
+    render(
+      <ContainersTable
+        containers={mockContainers}
+        isLoading={false}
+        onCopyToClipboard={mockCallback}
+      />
+    );
+
+    const rows = screen.getAllByRole('row');
+    fireEvent.click(rows[1]);
+
+    expect(screen.getByText('Labels')).toBeDefined();
+  });
+
+  it('expand button toggles label details independently of row click', () => {
+    const mockCallback = vi.fn();
+    render(
+      <ContainersTable
+        containers={mockContainers}
+        isLoading={false}
+        onCopyToClipboard={mockCallback}
+      />
+    );
+
+    const expandButtons = screen.getAllByRole('button', { name: /expand labels/i });
+    fireEvent.click(expandButtons[0]);
+
+    expect(screen.getByText('Labels')).toBeDefined();
+  });
+
+  it('shows no labels message when container has no labels', () => {
+    const mockCallback = vi.fn();
+    const container = createMockContainer({ labels: {} });
+    render(
+      <ContainersTable
+        containers={[container]}
+        isLoading={false}
+        onCopyToClipboard={mockCallback}
+      />
+    );
+
+    const expandButton = screen.getByRole('button', { name: /expand labels/i });
+    fireEvent.click(expandButton);
+
+    expect(screen.getByText('No labels')).toBeDefined();
+  });
+
+  it('shows proxy unreachable link and calls onProxyHelp when clicked', () => {
+    const mockCallback = vi.fn();
+    const onProxyHelp = vi.fn();
+    render(
+      <ContainersTable
+        containers={mockContainers}
+        isLoading={false}
+        onCopyToClipboard={mockCallback}
+        proxyUnreachable={true}
+        onProxyHelp={onProxyHelp}
+      />
+    );
+
+    const link = screen.getByText(/Extension backend not responding/i);
+    expect(link).toBeDefined();
+    fireEvent.click(link);
+    expect(onProxyHelp).toHaveBeenCalled();
+  });
+
+  it('pressing Enter on a row expands labels', () => {
+    const mockCallback = vi.fn();
+    render(
+      <ContainersTable
+        containers={mockContainers}
+        isLoading={false}
+        onCopyToClipboard={mockCallback}
+      />
+    );
+
+    const rows = screen.getAllByRole('row');
+    fireEvent.keyDown(rows[1], { key: 'Enter' });
+
+    expect(screen.getByText('Labels')).toBeDefined();
+  });
 });

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -49,6 +49,7 @@ export default defineConfig({
       provider: "v8",
       reporter: ["text", "lcov", "html"],
       reportsDirectory: "coverage",
+      exclude: ["src/main.tsx", "build/**"],
       thresholds: {
         lines: 80,
         functions: 80,


### PR DESCRIPTION
## Summary

- Backend Go coverage: 67.5% → 81.5%
- Proxy Go coverage: ~0% → 84.8%
- UI coverage: meets 80% threshold across all metrics
- All `make test`, `test-race`, `test-stress`, `bench`, `test-coverage`, and `lint` targets pass

## New test files

- `backend/monitor_test.go` — Docker event monitor, proxy socket server, `listen()`
- `backend/notify_test.go` — non-2xx response handling for notify helpers
- `backend/handlers_echo_test.go` — handler unit tests with `withNoOpNotify` helper
- `proxy/forward_test.go` — `forwardRequest` and `handleRequest` paths
- `proxy/notification_handler_test.go` — `handleConfigUpdate`, `handleContainerDestroyed`
- `proxy/listener_test.go` — `startNotificationListener`, `startForwardURLRefresher`

## ContainersTable UI tests added

Row expansion, expand button, no-labels branch, proxy unreachable link, keyboard navigation.

## Production changes (testability only)

- `backend/main.go`: `proxyNotificationSocketPath` const→var; `notifyProxyConfigUpdateFn` var; capture `socketPath` before retry loop to eliminate data races
- `proxy/main.go`: `forwardURLRefreshInterval` as package var; `startForwardURLRefresher` accepts `context.Context` for cancellation
- `ui/vite.config.ts`: exclude `src/main.tsx` and build artifacts from coverage reporting

## Test plan

- [ ] `make test` passes
- [ ] `make test-race` passes (no data races)
- [ ] `make test-stress` passes
- [ ] `make test-coverage` reports backend ≥80%, proxy ≥80%, UI ≥80%