### PR TITLE
feat: provider-agnostic network naming with per-provider proxy status

### DIFF
--- a/backend/handlers_echo_test.go
+++ b/backend/handlers_echo_test.go
@@ -198,12 +198,12 @@ func TestGetContainersWithData(t *testing.T) {
 		ContainerID: "abc",
 		Name:        "/test",
 		Labels:      map[string]string{},
-		Networks:    []NetworkInfo{{NetworkName: ".imds_aws_gcp", NetworkID: "net1"}},
+		Networks:    []NetworkInfo{{NetworkName: ".imds-0", NetworkID: "net1"}},
 	}
 	trackedContainersMutex.Unlock()
 
 	managedNetworksMutex.Lock()
-	managedNetworks = []ImdsNetworkStatus{{NetworkName: ".imds_aws_gcp", Providers: []string{"AWS", "GCP"}}}
+	managedNetworks = []ImdsNetwork{{NetworkName: ".imds-0", Providers: map[string][]string{"AWS": {"v4", "v6"}, "GCP": {"v4", "v6"}}}}
 	managedNetworksMutex.Unlock()
 	t.Cleanup(func() {
 		managedNetworksMutex.Lock()
@@ -231,11 +231,17 @@ func TestGetContainersWithData(t *testing.T) {
 	if len(result.Containers) != 1 {
 		t.Fatalf("want 1 container, got %d", len(result.Containers))
 	}
-	if len(result.Containers[0].ImdsNetworks) != 1 {
-		t.Fatalf("want 1 imds network, got %d", len(result.Containers[0].ImdsNetworks))
+	if len(result.Containers[0].Providers) != 2 {
+		t.Fatalf("want 2 providers (AWS, GCP), got %d", len(result.Containers[0].Providers))
 	}
-	if !result.Containers[0].ImdsNetworks[0].Connected {
-		t.Errorf("want ImdsNetworks[0].Connected=true for .imds_aws_gcp")
+	awsConnected := false
+	for _, p := range result.Containers[0].Providers {
+		if p.Name == "AWS" && p.IPv4Connected && p.IPv6Connected {
+			awsConnected = true
+		}
+	}
+	if !awsConnected {
+		t.Errorf("want AWS provider with IPv4+IPv6 connected for .imds-0")
 	}
 }
 

--- a/backend/integration_test.go
+++ b/backend/integration_test.go
@@ -141,7 +141,7 @@ func TestContainerLifecycleIntegration(t *testing.T) {
 		},
 		NetworkSettings: &container.NetworkSettings{
 			Networks: map[string]*network.EndpointSettings{
-				imdsNetworkAWSGCP: {
+				".imds-0": {
 					NetworkID: testNetworkID,
 					IPAddress: testIP,
 				},

--- a/backend/main.go
+++ b/backend/main.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -42,12 +43,10 @@ import (
 var logger = logrus.New()
 
 const (
-	imdsNetworkAWSGCP    = ".imds_aws_gcp"
-	imdsNetworkOpenStack = ".imds_openstack"
-	proxySocketPath      = "/var/run/imds-proxy/backend.sock"
-	imdsManagedLabel     = "imds-proxy.managed"
-	imdsProvidersLabel   = "imds-proxy.providers"
-	proxyContainerName   = "imds-proxy"
+	proxySocketPath    = "/var/run/imds-proxy/backend.sock"
+	imdsManagedLabel   = "imds-proxy.managed"
+	imdsProvidersLabel = "imds-proxy.providers"
+	proxyContainerName = "imds-proxy"
 )
 
 type ProxyContainerState string
@@ -81,18 +80,28 @@ type NetworkInfo struct {
 	NetworkName string `json:"networkName"`
 }
 
-type ImdsNetworkStatus struct {
-	NetworkName string   `json:"networkName"`
-	Providers   []string `json:"providers"`
-	Connected   bool     `json:"connected"`
+// ImdsNetwork is the internal representation of a managed IMDS network.
+// Providers maps provider name (e.g. "AWS") to the protocols it carries on
+// this network (e.g. ["v4", "v6"]).
+type ImdsNetwork struct {
+	NetworkName string
+	Providers   map[string][]string
+}
+
+// ProviderStatus is the per-container API representation of a cloud provider's
+// proxying state across all managed networks.
+type ProviderStatus struct {
+	Name          string `json:"name"`
+	IPv4Connected bool   `json:"ipv4Connected"`
+	IPv6Connected bool   `json:"ipv6Connected"`
 }
 
 type ContainerInfo struct {
-	ContainerID  string              `json:"containerId"`
-	Name         string              `json:"name"`
-	Labels       map[string]string   `json:"labels"`
-	Networks     []NetworkInfo       `json:"-"`
-	ImdsNetworks []ImdsNetworkStatus `json:"imdsNetworks"`
+	ContainerID string            `json:"containerId"`
+	Name        string            `json:"name"`
+	Labels      map[string]string `json:"labels"`
+	Networks    []NetworkInfo     `json:"-"`
+	Providers   []ProviderStatus  `json:"providers"`
 }
 
 type ContainersAPIResponse struct {
@@ -112,7 +121,7 @@ var (
 	ipToContainerID      = make(map[string]string)
 	ipToContainerIDMutex sync.RWMutex
 
-	managedNetworks      []ImdsNetworkStatus
+	managedNetworks      []ImdsNetwork
 	managedNetworksMutex sync.RWMutex
 
 	dockerClient DockerClient
@@ -629,12 +638,15 @@ func addContainerToTrackingWithNetwork(ctx context.Context, cli DockerClient, co
 	}
 
 	// Determine which networks need to be connected
+	managedNetworksMutex.RLock()
+	knownNetworks := managedNetworks
+	managedNetworksMutex.RUnlock()
+
 	networksToConnect := []string{}
-	if !connectedNetworks[imdsNetworkAWSGCP] {
-		networksToConnect = append(networksToConnect, imdsNetworkAWSGCP)
-	}
-	if !connectedNetworks[imdsNetworkOpenStack] {
-		networksToConnect = append(networksToConnect, imdsNetworkOpenStack)
+	for _, mn := range knownNetworks {
+		if !connectedNetworks[mn.NetworkName] {
+			networksToConnect = append(networksToConnect, mn.NetworkName)
+		}
 	}
 
 	// Connect to IMDS networks if needed
@@ -746,6 +758,80 @@ func refreshContainerNetworks(ctx context.Context, cli DockerClient, containerID
 	return nil
 }
 
+// parseProviderLabel parses the imds-proxy.providers label value into a map
+// of provider name to the protocols it carries on that network.
+// Format: "AWS=v4,v6;GCP=v4,v6;OpenStack=v4"
+func parseProviderLabel(s string) map[string][]string {
+	result := make(map[string][]string)
+	for _, entry := range strings.Split(s, ";") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		parts := strings.SplitN(entry, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		name := strings.TrimSpace(parts[0])
+		protos := []string{}
+		for _, p := range strings.Split(parts[1], ",") {
+			p = strings.TrimSpace(p)
+			if p != "" {
+				protos = append(protos, p)
+			}
+		}
+		if name != "" {
+			result[name] = protos
+		}
+	}
+	return result
+}
+
+// buildProviderStatuses aggregates per-provider connectivity across all managed
+// networks, given the set of networks the container is currently connected to.
+func buildProviderStatuses(containerNetworks []NetworkInfo, managedNets []ImdsNetwork) []ProviderStatus {
+	connectedNames := make(map[string]bool, len(containerNetworks))
+	for _, n := range containerNetworks {
+		connectedNames[n.NetworkName] = true
+	}
+
+	// Collect which protocols are connected per provider
+	connectedProtos := make(map[string]map[string]bool)
+	// Track all known provider names (to include disconnected ones)
+	allProviders := make(map[string]bool)
+
+	for _, mn := range managedNets {
+		connected := connectedNames[mn.NetworkName]
+		for provider, protos := range mn.Providers {
+			allProviders[provider] = true
+			if connected {
+				if connectedProtos[provider] == nil {
+					connectedProtos[provider] = make(map[string]bool)
+				}
+				for _, proto := range protos {
+					connectedProtos[provider][proto] = true
+				}
+			}
+		}
+	}
+
+	names := make([]string, 0, len(allProviders))
+	for name := range allProviders {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	statuses := make([]ProviderStatus, 0, len(names))
+	for _, name := range names {
+		statuses = append(statuses, ProviderStatus{
+			Name:          name,
+			IPv4Connected: connectedProtos[name]["v4"],
+			IPv6Connected: connectedProtos[name]["v6"],
+		})
+	}
+	return statuses
+}
+
 func discoverManagedNetworks(ctx context.Context, cli DockerClient) error {
 	networkList, err := cli.NetworkList(ctx, network.ListOptions{
 		Filters: filters.NewArgs(filters.Arg("label", imdsManagedLabel+"=true")),
@@ -754,17 +840,11 @@ func discoverManagedNetworks(ctx context.Context, cli DockerClient) error {
 		return err
 	}
 
-	discovered := make([]ImdsNetworkStatus, 0, len(networkList))
+	discovered := make([]ImdsNetwork, 0, len(networkList))
 	for _, n := range networkList {
-		providers := []string{}
-		if p := n.Labels[imdsProvidersLabel]; p != "" {
-			for _, provider := range strings.Split(p, ",") {
-				providers = append(providers, strings.TrimSpace(provider))
-			}
-		}
-		discovered = append(discovered, ImdsNetworkStatus{
+		discovered = append(discovered, ImdsNetwork{
 			NetworkName: n.Name,
-			Providers:   providers,
+			Providers:   parseProviderLabel(n.Labels[imdsProvidersLabel]),
 		})
 	}
 
@@ -786,19 +866,7 @@ func getContainers(ctx echo.Context) error {
 
 	containerList := make([]ContainerInfo, 0, len(trackedContainers))
 	for _, info := range trackedContainers {
-		connectedNames := make(map[string]bool, len(info.Networks))
-		for _, n := range info.Networks {
-			connectedNames[n.NetworkName] = true
-		}
-		imdsNetworks := make([]ImdsNetworkStatus, 0, len(networks))
-		for _, mn := range networks {
-			imdsNetworks = append(imdsNetworks, ImdsNetworkStatus{
-				NetworkName: mn.NetworkName,
-				Providers:   mn.Providers,
-				Connected:   connectedNames[mn.NetworkName],
-			})
-		}
-		info.ImdsNetworks = imdsNetworks
+		info.Providers = buildProviderStatuses(info.Networks, networks)
 		containerList = append(containerList, info)
 	}
 

--- a/backend/tracking_test.go
+++ b/backend/tracking_test.go
@@ -144,6 +144,18 @@ func TestAddAndRemoveContainerTracking(t *testing.T) {
 	resetTracking()
 	defer resetTracking()
 
+	managedNetworksMutex.Lock()
+	managedNetworks = []ImdsNetwork{
+		{NetworkName: ".imds-0", Providers: map[string][]string{"AWS": {"v4", "v6"}}},
+		{NetworkName: ".imds-1", Providers: map[string][]string{"OpenStack": {"v6"}}},
+	}
+	managedNetworksMutex.Unlock()
+	defer func() {
+		managedNetworksMutex.Lock()
+		managedNetworks = nil
+		managedNetworksMutex.Unlock()
+	}()
+
 	containerID := "abc123"
 	inspectInitial := container.InspectResponse{
 		ContainerJSONBase: &container.ContainerJSONBase{
@@ -169,10 +181,10 @@ func TestAddAndRemoveContainerTracking(t *testing.T) {
 		Config: &container.Config{Labels: map[string]string{}},
 		NetworkSettings: &container.NetworkSettings{
 			Networks: map[string]*network.EndpointSettings{
-				imdsNetworkAWSGCP: {
+				".imds-0": {
 					NetworkID: "net-aws",
 				},
-				imdsNetworkOpenStack: {
+				".imds-1": {
 					NetworkID: "net-os",
 				},
 			},
@@ -227,6 +239,17 @@ func TestAddContainerToTrackingWithNetworkPauseFirst(t *testing.T) {
 	resetTracking()
 	defer resetTracking()
 
+	managedNetworksMutex.Lock()
+	managedNetworks = []ImdsNetwork{
+		{NetworkName: ".imds-0", Providers: map[string][]string{"AWS": {"v4", "v6"}}},
+	}
+	managedNetworksMutex.Unlock()
+	defer func() {
+		managedNetworksMutex.Lock()
+		managedNetworks = nil
+		managedNetworksMutex.Unlock()
+	}()
+
 	containerID := "pause-test-abc"
 	inspectInitial := container.InspectResponse{
 		ContainerJSONBase: &container.ContainerJSONBase{
@@ -252,7 +275,7 @@ func TestAddContainerToTrackingWithNetworkPauseFirst(t *testing.T) {
 		Config: &container.Config{Labels: map[string]string{}},
 		NetworkSettings: &container.NetworkSettings{
 			Networks: map[string]*network.EndpointSettings{
-				imdsNetworkAWSGCP: {NetworkID: "net-aws"},
+				".imds-0": {NetworkID: "net-aws"},
 			},
 		},
 	}
@@ -1016,7 +1039,7 @@ func TestScanExistingContainersLabeledContainer(t *testing.T) {
 				Config: &container.Config{Labels: map[string]string{"imds-proxy.enabled": "true"}},
 				NetworkSettings: &container.NetworkSettings{
 					Networks: map[string]*network.EndpointSettings{
-						".imds_aws_gcp": {NetworkID: "net1"},
+						".imds-0": {NetworkID: "net1"},
 					},
 				},
 			},
@@ -1029,8 +1052,8 @@ func TestScanExistingContainersLabeledContainer(t *testing.T) {
 				Config: &container.Config{Labels: map[string]string{"imds-proxy.enabled": "true"}},
 				NetworkSettings: &container.NetworkSettings{
 					Networks: map[string]*network.EndpointSettings{
-						".imds_aws_gcp":   {NetworkID: "net1"},
-						".imds_openstack": {NetworkID: "net2"},
+						".imds-0":   {NetworkID: "net1"},
+						".imds-1": {NetworkID: "net2"},
 					},
 				},
 			},
@@ -1113,10 +1136,10 @@ func TestDiscoverManagedNetworksWithProviders(t *testing.T) {
 	cli := &fakeDockerClient{
 		networkList: []network.Summary{
 			{
-				Name: ".imds_aws_gcp",
+				Name: ".imds-0",
 				Labels: map[string]string{
 					"imds-proxy.managed":   "true",
-					"imds-proxy.providers": "AWS,GCP",
+					"imds-proxy.providers": "AWS=v4,v6;GCP=v4,v6;OpenStack=v4",
 				},
 			},
 		},
@@ -1133,14 +1156,19 @@ func TestDiscoverManagedNetworksWithProviders(t *testing.T) {
 	if len(nets) != 1 {
 		t.Fatalf("want 1 managed network, got %d", len(nets))
 	}
-	if nets[0].NetworkName != ".imds_aws_gcp" {
-		t.Errorf("want network name .imds_aws_gcp, got %s", nets[0].NetworkName)
+	if nets[0].NetworkName != ".imds-0" {
+		t.Errorf("want network name .imds-0, got %s", nets[0].NetworkName)
 	}
-	if len(nets[0].Providers) != 2 {
-		t.Fatalf("want 2 providers, got %d", len(nets[0].Providers))
+	if len(nets[0].Providers) != 3 {
+		t.Fatalf("want 3 providers, got %d", len(nets[0].Providers))
 	}
-	if nets[0].Providers[0] != "AWS" || nets[0].Providers[1] != "GCP" {
-		t.Errorf("want providers [AWS GCP], got %v", nets[0].Providers)
+	for _, name := range []string{"AWS", "GCP", "OpenStack"} {
+		if _, ok := nets[0].Providers[name]; !ok {
+			t.Errorf("want provider %s in Providers map, got %v", name, nets[0].Providers)
+		}
+	}
+	if got := nets[0].Providers["AWS"]; len(got) != 2 || got[0] != "v4" || got[1] != "v6" {
+		t.Errorf("want AWS=[v4 v6], got %v", got)
 	}
 }
 
@@ -1181,7 +1209,7 @@ func TestRefreshContainerNetworksTracked(t *testing.T) {
 				Config: &container.Config{Labels: map[string]string{}},
 				NetworkSettings: &container.NetworkSettings{
 					Networks: map[string]*network.EndpointSettings{
-						".imds_aws_gcp": {NetworkID: "updated-net1"},
+						".imds-0": {NetworkID: "updated-net1"},
 					},
 				},
 			},
@@ -1252,7 +1280,7 @@ func TestFindContainerByIPFound(t *testing.T) {
 		ContainerID: containerID,
 		Name:        "/ip-test",
 		Labels:      map[string]string{"app": "test"},
-		Networks:    []NetworkInfo{{NetworkName: ".imds_aws_gcp", NetworkID: "net-x"}},
+		Networks:    []NetworkInfo{{NetworkName: ".imds-0", NetworkID: "net-x"}},
 	}
 	trackedContainersMutex.Unlock()
 
@@ -1267,7 +1295,7 @@ func TestFindContainerByIPFound(t *testing.T) {
 				Config: &container.Config{Labels: map[string]string{"app": "test"}},
 				NetworkSettings: &container.NetworkSettings{
 					Networks: map[string]*network.EndpointSettings{
-						".imds_aws_gcp": {NetworkID: "net-x", IPAddress: "10.5.0.42"},
+						".imds-0": {NetworkID: "net-x", IPAddress: "10.5.0.42"},
 					},
 				},
 			},
@@ -1296,7 +1324,7 @@ func TestFindContainerByIPNotFound(t *testing.T) {
 		ContainerID: containerID,
 		Name:        "/no-ip",
 		Labels:      map[string]string{},
-		Networks:    []NetworkInfo{{NetworkName: ".imds_aws_gcp", NetworkID: "net-y"}},
+		Networks:    []NetworkInfo{{NetworkName: ".imds-0", NetworkID: "net-y"}},
 	}
 	trackedContainersMutex.Unlock()
 
@@ -1311,7 +1339,7 @@ func TestFindContainerByIPNotFound(t *testing.T) {
 				Config: &container.Config{Labels: map[string]string{}},
 				NetworkSettings: &container.NetworkSettings{
 					Networks: map[string]*network.EndpointSettings{
-						".imds_aws_gcp": {NetworkID: "net-y", IPAddress: "10.5.0.1"},
+						".imds-0": {NetworkID: "net-y", IPAddress: "10.5.0.1"},
 					},
 				},
 			},
@@ -1337,7 +1365,7 @@ func TestFindContainerByIPInspectError(t *testing.T) {
 		ContainerID: containerID,
 		Name:        "/err-container",
 		Labels:      map[string]string{},
-		Networks:    []NetworkInfo{{NetworkName: ".imds_aws_gcp", NetworkID: "net-z"}},
+		Networks:    []NetworkInfo{{NetworkName: ".imds-0", NetworkID: "net-z"}},
 	}
 	trackedContainersMutex.Unlock()
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,12 +22,12 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
     networks:
-      # Connects to the AWS/GCP dual-stack network
-      imds_aws_gcp:
+      # IPv4 + EC2 IPv6 IMDS addresses (AWS, GCP, OpenStack v4)
+      imds_0:
         ipv4_address: 169.254.169.254
         ipv6_address: "fd00:ec2::254"
-      # Connects to the OpenStack IPv6-only network
-      imds_openstack:
+      # OpenStack IPv6 IMDS address
+      imds_1:
         ipv6_address: "fd00:a9fe:a9fe::254"
     volumes:
       # So we can communicate with the controller
@@ -40,27 +40,27 @@ volumes:
   imds-proxy-sockets:
 
 networks:
-  # Network 1: Handles IPv4 IMDS and standard EC2/GCP IPv6 IMDS ranges
-  imds_aws_gcp:
-    name: ".imds_aws_gcp"
+  # Network 0: IPv4 IMDS (169.254.169.254) + EC2 IPv6 (fd00:ec2::254)
+  imds_0:
+    name: ".imds-0"
     driver: bridge
     enable_ipv6: true
     labels:
       imds-proxy.managed: "true"
-      imds-proxy.providers: "AWS,GCP"
+      imds-proxy.providers: "AWS=v4,v6;GCP=v4,v6;OpenStack=v4"
     ipam:
       config:
         - subnet: 169.254.169.0/24
         - subnet: "fd00:ec2::/64"
 
-  # Network 2: Dedicated to the OpenStack IPv6 metadata range
-  imds_openstack:
-    name: ".imds_openstack"
+  # Network 1: OpenStack IPv6 IMDS address (fd00:a9fe:a9fe::254)
+  imds_1:
+    name: ".imds-1"
     driver: bridge
     enable_ipv6: true
     labels:
       imds-proxy.managed: "true"
-      imds-proxy.providers: "OpenStack"
+      imds-proxy.providers: "OpenStack=v6"
     ipam:
       config:
         - subnet: "fd00:a9fe:a9fe::/64"

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -258,30 +258,36 @@ export function App() {
             <Typography variant="body2">
               Add the following label to a container to enable IMDS proxying:
             </Typography>
-            <Box
-              component="code"
-              sx={{
-                px: 1,
-                py: 0.25,
-                borderRadius: 0.5,
-                bgcolor: 'action.hover',
-                border: '1px solid',
-                borderColor: 'divider',
-                fontFamily: 'monospace',
-                fontSize: '0.875rem',
-                whiteSpace: 'nowrap',
-              }}
-            >
-              {IMDS_PROXY_ENABLED_LABEL}
-            </Box>
             <Tooltip title="Copy label">
-              <IconButton
-                size="small"
-                aria-label="Copy label to clipboard"
+              <Box
+                component="code"
                 onClick={() => copyToClipboard(IMDS_PROXY_ENABLED_LABEL, 'label')}
+                aria-label="Copy label to clipboard"
+                role="button"
+                tabIndex={0}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') copyToClipboard(IMDS_PROXY_ENABLED_LABEL, 'label');
+                }}
+                sx={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 0.5,
+                  px: 1,
+                  py: 0.25,
+                  borderRadius: 0.5,
+                  bgcolor: 'action.hover',
+                  border: '1px solid',
+                  borderColor: 'divider',
+                  fontFamily: 'monospace',
+                  fontSize: '0.875rem',
+                  whiteSpace: 'nowrap',
+                  cursor: 'pointer',
+                  '&:hover': { bgcolor: 'action.selected' },
+                }}
               >
-                <ContentCopyIcon fontSize="small" />
-              </IconButton>
+                {IMDS_PROXY_ENABLED_LABEL}
+                <ContentCopyIcon sx={{ fontSize: '0.75rem', opacity: 0.6 }} />
+              </Box>
             </Tooltip>
           </Stack>
 

--- a/ui/src/__tests__/testHelpers.ts
+++ b/ui/src/__tests__/testHelpers.ts
@@ -58,9 +58,10 @@ export const createMockContainer = (overrides?: Partial<ContainerInfo>): Contain
   containerId: 'abc123def456ghi789jkl012mno345pqr678',
   name: '/test-container',
   labels: { ...TEST_LABELS },
-  imdsNetworks: [
-    { networkName: '.imds_aws_gcp', providers: ['AWS', 'GCP'], connected: true },
-    { networkName: '.imds_openstack', providers: ['OpenStack'], connected: true },
+  providers: [
+    { name: 'AWS', ipv4Connected: true, ipv6Connected: true },
+    { name: 'GCP', ipv4Connected: true, ipv6Connected: true },
+    { name: 'OpenStack', ipv4Connected: true, ipv6Connected: true },
   ],
   ...overrides,
 });
@@ -73,9 +74,10 @@ export const createMockContainers = (count: number = 3): ContainerInfo[] => {
     containerId: `container-id-${i.toString().padStart(32, '0')}`,
     name: `/container-${i}`,
     labels: { ...TEST_LABELS },
-    imdsNetworks: [
-      { networkName: '.imds_aws_gcp', providers: ['AWS', 'GCP'], connected: true },
-      { networkName: '.imds_openstack', providers: ['OpenStack'], connected: true },
+    providers: [
+      { name: 'AWS', ipv4Connected: true, ipv6Connected: true },
+      { name: 'GCP', ipv4Connected: true, ipv6Connected: true },
+      { name: 'OpenStack', ipv4Connected: true, ipv6Connected: true },
     ],
   }));
 };

--- a/ui/src/components/ContainersTable.tsx
+++ b/ui/src/components/ContainersTable.tsx
@@ -35,7 +35,7 @@ import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import Link from '@mui/material/Link';
-import { ContainerInfo } from '../types';
+import { ContainerInfo, isProviderFullyConnected, isProviderPartiallyConnected } from '../types';
 import { CONTAINER_ID_DISPLAY_LENGTH } from '../constants';
 import { cleanContainerName } from '../utils/containerUtils';
 
@@ -140,7 +140,7 @@ export function ContainersTable({
                   Container ID
                 </TableSortLabel>
               </TableCell>
-              <TableCell>IMDS Networks</TableCell>
+              <TableCell>Providers</TableCell>
               <TableCell padding="checkbox" />
             </TableRow>
           </TableHead>
@@ -225,20 +225,35 @@ export function ContainersTable({
                     </TableCell>
                     <TableCell>
                       <Stack direction="row" spacing={0.5} flexWrap="wrap" useFlexGap>
-                        {[...container.imdsNetworks]
-                          .sort((a, b) => a.networkName.localeCompare(b.networkName))
-                          .map((n) => {
-                            const providerLabel = n.providers.join(' / ');
-                            const tooltipText = n.connected
-                              ? `${n.providers.join(' and ')} IMDS requests are being proxied for this container.`
-                              : `${n.providers.join(' and ')} IMDS requests will not be proxied. This container is not connected to the required network.`;
+                        {[...container.providers]
+                          .sort((a, b) => a.name.localeCompare(b.name))
+                          .map((p) => {
+                            const full = isProviderFullyConnected(p);
+                            const partial = isProviderPartiallyConnected(p);
+                            const color = full ? 'success' : partial ? 'warning' : 'error';
+                            const tooltipContent = (
+                              <Box>
+                                <Typography variant="caption" sx={{ fontWeight: 600 }}>
+                                  {p.name}
+                                </Typography>
+                                <Box component="div">
+                                  <Typography variant="caption" display="block">
+                                    {p.ipv4Connected ? '✓' : '✗'} IPv4
+                                  </Typography>
+                                  <Typography variant="caption" display="block">
+                                    {p.ipv6Connected ? '✓' : '✗'} IPv6
+                                  </Typography>
+                                </Box>
+                              </Box>
+                            );
                             return (
-                              <Tooltip key={n.networkName} title={tooltipText}>
+                              <Tooltip key={p.name} title={tooltipContent}>
                                 <Chip
-                                  label={providerLabel}
-                                  color={n.connected ? 'success' : 'error'}
+                                  label={p.name}
+                                  color={color}
                                   size="small"
                                   variant="outlined"
+                                  tabIndex={0}
                                 />
                               </Tooltip>
                             );

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 /**
- * Status of a Barnacle-managed IMDS network for a container
+ * Per-provider IMDS proxying status for a container
  */
-export interface ImdsNetworkStatus {
-  networkName: string;
-  providers: string[];
-  connected: boolean;
+export interface ProviderStatus {
+  name: string;
+  ipv4Connected: boolean;
+  ipv6Connected: boolean;
 }
 
 /**
@@ -28,7 +28,7 @@ export interface ContainerInfo {
   containerId: string;
   name: string;
   labels: Record<string, string>;
-  imdsNetworks: ImdsNetworkStatus[];
+  providers: ProviderStatus[];
 }
 
 /**
@@ -68,3 +68,15 @@ export const isContainersResponse = (value: unknown): value is ContainersRespons
   const v = value as Record<string, unknown>;
   return Array.isArray(v.containers) && typeof v.proxyStatus === 'string';
 };
+
+/**
+ * Returns true if the provider has full proxying (both IPv4 and IPv6)
+ */
+export const isProviderFullyConnected = (p: ProviderStatus): boolean =>
+  p.ipv4Connected && p.ipv6Connected;
+
+/**
+ * Returns true if the provider has partial proxying (one of IPv4/IPv6)
+ */
+export const isProviderPartiallyConnected = (p: ProviderStatus): boolean =>
+  p.ipv4Connected !== p.ipv6Connected;


### PR DESCRIPTION
## Summary

- Rename IMDS networks from provider-specific names to `.imds-0` / `.imds-1`; the `imds-proxy.providers` label (`AWS=v4,v6;GCP=v4,v6;OpenStack=v4`) is now the sole source of truth for what each network carries
- Backend parses the label format and aggregates per-provider IPv4/IPv6 connectivity across all managed networks a container is connected to
- UI container table switches from per-network pills to per-provider pills with green/yellow/red status; tooltips show a stacked ✓/✗ breakdown per protocol; pills are in tab order
- Copy icon for the "enable IMDS proxying" label is now inline inside the code element rather than a separate button

## Test plan

- [x] `make test` passes (Go + UI)
- [x] Container connected to both networks shows all providers green with ✓ IPv4 ✓ IPv6
- [x] Container connected to `.imds-0` only shows OpenStack as yellow (✓ IPv4 ✗ IPv6)
- [x] Container connected to neither shows all providers red
- [x] Clicking the label code pill copies to clipboard
- [x] Pills are keyboard-accessible (tab to focus, tooltip appears)