### PR TITLE
fix: e2e test improvements, settings polling, and proxy state tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ temp/
 .env
 
 node-compile-cache/
+docker-desktop-imds-proxy
+docker-desktop-imds-proxy-proxy

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ COPY logo.svg /ui/src/logo.svg
 RUN pnpm run build
 
 FROM alpine
+RUN apk add --no-cache curl
 ARG DESCRIPTION="Description not set"
 LABEL org.opencontainers.image.title="Barnacle IMDS Proxy" \
     org.opencontainers.image.description="${DESCRIPTION}" \

--- a/backend/integration_test.go
+++ b/backend/integration_test.go
@@ -76,6 +76,10 @@ func (m *mockDockerClientWithEvents) ContainerUnpause(_ context.Context, _ strin
 	return nil
 }
 
+func (m *mockDockerClientWithEvents) NetworkList(_ context.Context, _ network.ListOptions) ([]network.Summary, error) {
+	return []network.Summary{}, nil
+}
+
 func (m *mockDockerClientWithEvents) Close() error {
 	close(m.eventsChan)
 	close(m.errorChan)

--- a/backend/proxy_status_test.go
+++ b/backend/proxy_status_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Matt Miller
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/docker/docker/api/types/container"
+)
+
+func proxyContainer(state string) container.Summary {
+	return container.Summary{
+		Names: []string{"/" + proxyContainerName},
+		State: state,
+	}
+}
+
+func TestQueryProxyContainerStateRunning(t *testing.T) {
+	cli := &fakeDockerClient{containerList: []container.Summary{proxyContainer("running")}}
+	got := queryProxyContainerState(context.Background(), cli)
+	if got != ProxyStateRunning {
+		t.Errorf("want %q, got %q", ProxyStateRunning, got)
+	}
+}
+
+func TestQueryProxyContainerStatePaused(t *testing.T) {
+	cli := &fakeDockerClient{containerList: []container.Summary{proxyContainer("paused")}}
+	got := queryProxyContainerState(context.Background(), cli)
+	if got != ProxyStatePaused {
+		t.Errorf("want %q, got %q", ProxyStatePaused, got)
+	}
+}
+
+func TestQueryProxyContainerStateDead(t *testing.T) {
+	cli := &fakeDockerClient{containerList: []container.Summary{proxyContainer("dead")}}
+	got := queryProxyContainerState(context.Background(), cli)
+	if got != ProxyStateFailed {
+		t.Errorf("want %q, got %q", ProxyStateFailed, got)
+	}
+}
+
+func TestQueryProxyContainerStateExited(t *testing.T) {
+	cli := &fakeDockerClient{containerList: []container.Summary{proxyContainer("exited")}}
+	got := queryProxyContainerState(context.Background(), cli)
+	if got != ProxyStateStopped {
+		t.Errorf("want %q, got %q", ProxyStateStopped, got)
+	}
+}
+
+func TestQueryProxyContainerStateMissing(t *testing.T) {
+	cli := &fakeDockerClient{containerList: []container.Summary{}}
+	got := queryProxyContainerState(context.Background(), cli)
+	if got != ProxyStateMissing {
+		t.Errorf("want %q, got %q", ProxyStateMissing, got)
+	}
+}
+
+func TestQueryProxyContainerStateListError(t *testing.T) {
+	cli := &fakeDockerClient{containerListErr: errors.New("docker unavailable")}
+	got := queryProxyContainerState(context.Background(), cli)
+	if got != ProxyStateMissing {
+		t.Errorf("want %q on error, got %q", ProxyStateMissing, got)
+	}
+}
+
+func TestQueryProxyContainerStateIgnoresOtherContainers(t *testing.T) {
+	other := container.Summary{Names: []string{"/some-other-container"}, State: "running"}
+	cli := &fakeDockerClient{containerList: []container.Summary{other}}
+	got := queryProxyContainerState(context.Background(), cli)
+	if got != ProxyStateMissing {
+		t.Errorf("want %q for unrelated container, got %q", ProxyStateMissing, got)
+	}
+}

--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -13,29 +13,55 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# End-to-end tests for barnacle-imds-proxy.
+#
+# BACKEND controls which upstream server is used:
+#   BACKEND=test-server  (default) — starts the built-in Go test server on TEST_SERVER_PORT
+#   BACKEND=imds-server             — expects imds-server already running; skips echo-header tests
+#
+# The extension must be configured to point at the appropriate backend URL before running.
 
 CONTAINER_NAME="imds-e2e-test"
-TEST_SERVER_PORT=8080
+BACKEND="${BACKEND:-test-server}"
+TEST_SERVER_PORT="${TEST_SERVER_PORT:-8080}"
+IMDS_SERVER_PORT="${IMDS_SERVER_PORT:-3333}"
 TEST_SERVER_PID=""
+CONTROLLER_SOCKET="/run/guest-services/backend.sock"
+
+# Update the extension backend URL via the controller's settings API
+set_backend_url() {
+    local url="$1"
+    docker exec imds-proxy-controller \
+        curl -sf --unix-socket "$CONTROLLER_SOCKET" \
+        -X POST -H 'Content-Type: application/json' \
+        -d "{\"url\":\"$url\"}" \
+        http://localhost/settings >/dev/null
+}
 
 setup_file() {
-    # Build and start the test server
-    cd "$BATS_TEST_DIRNAME/../test-server"
-    go build -o "$BATS_FILE_TMPDIR/test-server" .
-    "$BATS_FILE_TMPDIR/test-server" -port="$TEST_SERVER_PORT" &
-    TEST_SERVER_PID=$!
-    echo "$TEST_SERVER_PID" > "$BATS_FILE_TMPDIR/test-server.pid"
+    if [ "$BACKEND" = "test-server" ]; then
+        # Build and start the test server
+        cd "$BATS_TEST_DIRNAME/../test-server"
+        go build -o "$BATS_FILE_TMPDIR/test-server" .
+        "$BATS_FILE_TMPDIR/test-server" -port="$TEST_SERVER_PORT" &
+        TEST_SERVER_PID=$!
+        echo "$TEST_SERVER_PID" > "$BATS_FILE_TMPDIR/test-server.pid"
 
-    # Wait for it to be ready
-    for i in $(seq 1 10); do
-        if curl -sf "http://localhost:$TEST_SERVER_PORT/" >/dev/null 2>&1; then
-            break
+        # Wait for it to be ready
+        for i in $(seq 1 10); do
+            if curl -sf "http://localhost:$TEST_SERVER_PORT/status" >/dev/null 2>&1; then
+                break
+            fi
+            sleep 1
+        done
+        if ! curl -sf "http://localhost:$TEST_SERVER_PORT/status" >/dev/null 2>&1; then
+            echo "Test server failed to start on port $TEST_SERVER_PORT" >&2
+            return 1
         fi
-        sleep 1
-    done
-    if ! curl -sf "http://localhost:$TEST_SERVER_PORT/" >/dev/null 2>&1; then
-        echo "Test server failed to start on port $TEST_SERVER_PORT" >&2
-        return 1
+
+        set_backend_url "http://localhost:$TEST_SERVER_PORT"
+    else
+        set_backend_url "http://localhost:$IMDS_SERVER_PORT"
     fi
 
     # Start a labeled container
@@ -45,7 +71,7 @@ setup_file() {
     # Wait for controller to attach networks
     for i in $(seq 1 15); do
         networks=$(docker inspect "$CONTAINER_NAME" --format '{{range $k, $v := .NetworkSettings.Networks}}{{$k}} {{end}}' 2>/dev/null || echo "")
-        if echo "$networks" | grep -q 'imds_aws_gcp'; then
+        if echo "$networks" | grep -q '\.imds-0'; then
             return 0
         fi
         sleep 1
@@ -63,42 +89,44 @@ teardown_file() {
 
 # --- network tests ---
 
-@test "imds_aws_gcp network exists" {
-    docker network ls --format '{{.Name}}' | grep -q '\.imds_aws_gcp'
+@test ".imds-0 network exists" {
+    docker network ls --format '{{.Name}}' | grep -q '\.imds-0'
 }
 
-@test "imds_openstack network exists" {
-    docker network ls --format '{{.Name}}' | grep -q '\.imds_openstack'
+@test ".imds-1 network exists" {
+    docker network ls --format '{{.Name}}' | grep -q '\.imds-1'
 }
 
 @test "container is attached to IMDS networks" {
     networks=$(docker inspect "$CONTAINER_NAME" --format '{{range $k, $v := .NetworkSettings.Networks}}{{$k}} {{end}}')
-    echo "$networks" | grep -q 'imds_aws_gcp'
-    echo "$networks" | grep -q 'imds_openstack'
+    echo "$networks" | grep -q '\.imds-0'
+    echo "$networks" | grep -q '\.imds-1'
 }
 
-# --- reachability tests ---
+# --- reachability tests (use /status — present on both backends) ---
 
 @test "IPv4 169.254.169.254 is reachable" {
-    docker exec "$CONTAINER_NAME" wget -qO- --timeout=5 http://169.254.169.254/
+    docker exec "$CONTAINER_NAME" wget -qO- --timeout=5 http://169.254.169.254/status
 }
 
 @test "IPv6 fd00:ec2::254 is reachable" {
-    docker exec "$CONTAINER_NAME" wget -qO- --timeout=5 "http://[fd00:ec2::254]/"
+    docker exec "$CONTAINER_NAME" wget -qO- --timeout=5 "http://[fd00:ec2::254]/status"
 }
 
 @test "IPv6 fd00:a9fe:a9fe::254 is reachable" {
-    docker exec "$CONTAINER_NAME" wget -qO- --timeout=5 "http://[fd00:a9fe:a9fe::254]/"
+    docker exec "$CONTAINER_NAME" wget -qO- --timeout=5 "http://[fd00:a9fe:a9fe::254]/status"
 }
 
-# --- proxy header tests (require test server running and extension pointed at localhost:8080) ---
+# --- proxy header tests (test-server only) ---
 
 @test "X-Container-Id header is forwarded" {
+    [ "$BACKEND" = "test-server" ] || skip "requires test-server backend"
     run docker exec "$CONTAINER_NAME" wget -qS --timeout=5 http://169.254.169.254/ -O /dev/null 2>&1
     echo "$output" | grep -qi 'X-Echo-X-Container-Id'
 }
 
 @test "X-Container-Name header is forwarded" {
+    [ "$BACKEND" = "test-server" ] || skip "requires test-server backend"
     run docker exec "$CONTAINER_NAME" wget -qS --timeout=5 http://169.254.169.254/ -O /dev/null 2>&1
     echo "$output" | grep -qi 'X-Echo-X-Container-Name'
 }

--- a/ui/src/components/SettingsForm.tsx
+++ b/ui/src/components/SettingsForm.tsx
@@ -41,6 +41,10 @@ export function SettingsForm({ ddClient, service, showSnackbar, proxyUnreachable
   const [url, setUrl] = useState('');
   const [urlError, setUrlError] = useState('');
   const [savedUrl, setSavedUrl] = useState('');
+
+  // Keep refs in sync so polling callbacks can read current values without stale closures
+  useEffect(() => { urlRef.current = url; }, [url]);
+  useEffect(() => { savedUrlRef.current = savedUrl; }, [savedUrl]);
   const [isSaving, setIsSaving] = useState(false);
   const [isLoadingSettings, setIsLoadingSettings] = useState(false);
   const [isDebouncing, setIsDebouncing] = useState(false);
@@ -48,6 +52,8 @@ export function SettingsForm({ ddClient, service, showSnackbar, proxyUnreachable
 
   // Track mount status to prevent state updates after unmount during async settings load
   const isMountedRef = useRef(false);
+  const urlRef = useRef(url);
+  const savedUrlRef = useRef(savedUrl);
 
   useEffect(() => {
     if (!ddClient) {
@@ -87,8 +93,16 @@ export function SettingsForm({ ddClient, service, showSnackbar, proxyUnreachable
 
     loadSettings();
 
+    // Poll for external settings changes, but skip if the user has unsaved edits
+    const pollInterval = setInterval(() => {
+      if (isMountedRef.current && urlRef.current === savedUrlRef.current) {
+        loadSettings();
+      }
+    }, 5000);
+
     return () => {
       isMountedRef.current = false;
+      clearInterval(pollInterval);
     };
   }, [ddClient, service, showSnackbar]);
 

--- a/ui/src/components/SettingsForm.tsx
+++ b/ui/src/components/SettingsForm.tsx
@@ -62,8 +62,8 @@ export function SettingsForm({ ddClient, service, showSnackbar, proxyUnreachable
     isMountedRef.current = true;
 
     // Load saved settings from backend
-    const loadSettings = async () => {
-      setIsLoadingSettings(true);
+    const loadSettings = async (showSkeleton = true) => {
+      if (showSkeleton) setIsLoadingSettings(true);
       try {
         const result = await withTimeout(service.getSettings(), BACKEND_REQUEST_TIMEOUT_MS);
         if (isSettingsResponse(result)) {
@@ -85,7 +85,7 @@ export function SettingsForm({ ddClient, service, showSnackbar, proxyUnreachable
           setSavedUrl(savedUrl);
         }
       } finally {
-        if (isMountedRef.current) {
+        if (showSkeleton && isMountedRef.current) {
           setIsLoadingSettings(false);
         }
       }
@@ -96,7 +96,7 @@ export function SettingsForm({ ddClient, service, showSnackbar, proxyUnreachable
     // Poll for external settings changes, but skip if the user has unsaved edits
     const pollInterval = setInterval(() => {
       if (isMountedRef.current && urlRef.current === savedUrlRef.current) {
-        loadSettings();
+        loadSettings(false);
       }
     }, 5000);
 


### PR DESCRIPTION
## Summary

- Updates e2e tests for new `.imds-0`/`.imds-1` network names, adds dual-backend support (`BACKEND=test-server` / `BACKEND=imds-server`), auto-configures the extension URL via the controller socket, and uses `localhost` URLs to exercise proxy rewrite
- Adds missing `NetworkList` stub to integration test mock; adds `curl` to the controller Dockerfile for e2e automation
- Settings tab polls backend every 5 seconds for externally-changed settings (silently, no skeleton flicker), guarded against overwriting unsaved edits
- Adds unit tests for `queryProxyContainerState`

## Test plan

- [x] `make test` passes
- [x] `make update-extension` reloads cleanly
- [x] Settings tab reflects external URL changes within ~5s without flickering
- [x] e2e tests pass in both `BACKEND=test-server` and `BACKEND=imds-server` modes