### PR TITLE
fix(ui): backend unreachable UX improvements

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -104,6 +104,10 @@ export function App() {
   const isMountedRef = useRef(false);
   // Only show the loading skeleton on the first fetch, not on background poll refreshes
   const hasLoadedOnceRef = useRef(false);
+  // Require 2 consecutive failures before showing the unreachable banner, to avoid
+  // flicker when the controller is briefly unavailable during startup or restart
+  const consecutiveFailuresRef = useRef(0);
+  const UNREACHABLE_THRESHOLD = 2;
 
   const showSnackbar = useCallback((message: string, severity: 'success' | 'error') => {
     setSnackbarMessage(message);
@@ -123,6 +127,7 @@ export function App() {
       const result = await withTimeout(service.getContainers(), BACKEND_REQUEST_TIMEOUT_MS);
       if (isContainersResponse(result) && isMountedRef.current) {
         hasLoadedOnceRef.current = true;
+        consecutiveFailuresRef.current = 0;
         setContainers(result.containers);
         setProxyContainerState(result.proxyStatus);
         setProxyUnreachable(false);
@@ -131,7 +136,8 @@ export function App() {
       }
     } catch (error) {
       console.error('Failed to load containers:', error);
-      if (isMountedRef.current) {
+      consecutiveFailuresRef.current += 1;
+      if (isMountedRef.current && consecutiveFailuresRef.current >= UNREACHABLE_THRESHOLD) {
         setProxyUnreachable(true);
       }
     } finally {
@@ -336,39 +342,49 @@ export function App() {
         <DialogContent>
           <Typography variant="body2" sx={{ mb: 1.5 }}>
             The Barnacle controller is not responding, so the container list may be outdated.
-            The IMDS proxy runs separately and may still be proxying IMDS traffic correctly.
-            To restore full functionality, try the following steps:
+            The IMDS proxy runs separately and may still be forwarding traffic correctly.
+            Try the following steps in order until it recovers:
           </Typography>
           <List dense disablePadding>
             <ListItem sx={{ alignItems: 'flex-start', pl: 0 }}>
               <ListItemText
-                primary="1. Restart the extension"
-                secondary="In Docker Desktop, open the Extensions Marketplace, find Barnacle, and click Disable then Enable."
+                primary="1. Navigate away and return"
+                secondary="Click another section in the Docker Desktop sidebar, then come back to this extension."
               />
             </ListItem>
             <ListItem sx={{ alignItems: 'flex-start', pl: 0 }}>
               <ListItemText
-                primary="2. Restart Docker Desktop"
+                primary="2. Disable and re-enable the extension"
+                secondary="In the Extensions Marketplace, find Barnacle and click Disable, then Enable."
+              />
+            </ListItem>
+            <ListItem sx={{ alignItems: 'flex-start', pl: 0 }}>
+              <ListItemText
+                primary="3. Restart Docker Desktop"
                 secondary="Quit and relaunch Docker Desktop. This restarts all extension services."
               />
             </ListItem>
             <ListItem sx={{ alignItems: 'flex-start', pl: 0 }}>
               <ListItemText
-                primary="3. Still not working?"
+                primary="4. Reboot"
                 secondary={
-                  <Link
-                    href="#"
-                    onClick={(e) => {
-                      e.preventDefault();
-                      if (ddClient?.host?.openExternal) {
-                        ddClient.host.openExternal(`${GITHUB_REPO_URL}#troubleshooting`);
-                      } else {
-                        window.open(`${GITHUB_REPO_URL}#troubleshooting`, '_blank', 'noopener,noreferrer');
-                      }
-                    }}
-                  >
-                    View the troubleshooting guide
-                  </Link>
+                  <>
+                    {"Still not working? Reboot your machine, then "}
+                    <Link
+                      href="#"
+                      onClick={(e) => {
+                        e.preventDefault();
+                        if (ddClient?.host?.openExternal) {
+                          ddClient.host.openExternal(`${GITHUB_REPO_URL}#troubleshooting`);
+                        } else {
+                          window.open(`${GITHUB_REPO_URL}#troubleshooting`, '_blank', 'noopener,noreferrer');
+                        }
+                      }}
+                    >
+                      view the troubleshooting guide
+                    </Link>
+                    {" if the problem persists."}
+                  </>
                 }
               />
             </ListItem>

--- a/ui/src/__tests__/containersTable.test.tsx
+++ b/ui/src/__tests__/containersTable.test.tsx
@@ -237,7 +237,7 @@ describe('ContainersTable', () => {
     expect(screen.getByText('No labels')).toBeDefined();
   });
 
-  it('shows proxy unreachable link and calls onProxyHelp when clicked', () => {
+  it('shows proxy unreachable alert and calls onProxyHelp when Get help is clicked', () => {
     const mockCallback = vi.fn();
     const onProxyHelp = vi.fn();
     render(
@@ -250,9 +250,8 @@ describe('ContainersTable', () => {
       />
     );
 
-    const link = screen.getByText(/Extension backend not responding/i);
-    expect(link).toBeDefined();
-    fireEvent.click(link);
+    expect(screen.getByText(/Extension backend not responding/i)).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: /get help/i }));
     expect(onProxyHelp).toHaveBeenCalled();
   });
 

--- a/ui/src/components/ContainersTable.tsx
+++ b/ui/src/components/ContainersTable.tsx
@@ -30,11 +30,12 @@ import {
   Collapse,
   Box,
   Skeleton,
+  Alert,
+  Button,
 } from '@mui/material';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
-import Link from '@mui/material/Link';
 import { ContainerInfo, isProviderFullyConnected, isProviderPartiallyConnected } from '../types';
 import { CONTAINER_ID_DISPLAY_LENGTH } from '../constants';
 import { cleanContainerName } from '../utils/containerUtils';
@@ -322,24 +323,25 @@ export function ContainersTable({
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 }}>
       <Typography variant="subtitle1" sx={{ mb: 1 }}>Enabled for these containers</Typography>
+      {proxyUnreachable && (
+        <Alert
+          severity="warning"
+          sx={{ mb: 1, alignItems: 'center' }}
+          action={
+            onProxyHelp && (
+              <Button color="inherit" size="small" onClick={onProxyHelp}>
+                Get help
+              </Button>
+            )
+          }
+        >
+          Extension backend not responding — list may be outdated.
+        </Alert>
+      )}
       <Box sx={{ flex: 1, overflow: 'hidden', display: 'flex', flexDirection: 'column', minHeight: 0 }}>
         {renderContent()}
       </Box>
-      <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mt: 0.5 }}>
-        <Box>
-          {proxyUnreachable && (
-            <Link
-              component="button"
-              variant="body2"
-              color="error"
-              onClick={onProxyHelp}
-              disabled={!onProxyHelp}
-              sx={{ textDecoration: 'underline' }}
-            >
-              Extension backend not responding — list may be outdated
-            </Link>
-          )}
-        </Box>
+      <Stack direction="row" justifyContent="flex-end" alignItems="center" sx={{ mt: 0.5 }}>
         <Typography variant="body2" color="text.secondary">
           Showing {containers.length} {containers.length === 1 ? 'item' : 'items'}
         </Typography>

--- a/ui/src/components/SettingsForm.tsx
+++ b/ui/src/components/SettingsForm.tsx
@@ -167,6 +167,7 @@ export function SettingsForm({ ddClient, service, showSnackbar, proxyUnreachable
       {proxyUnreachable && (
         <Alert
           severity="warning"
+          sx={{ alignItems: 'center' }}
           action={
             onProxyHelp && (
               <Button color="inherit" size="small" onClick={onProxyHelp}>


### PR DESCRIPTION
## Summary

- Replaces the red footer link on the Containers tab with a warning Alert + "Get help" button, matching the Settings tab — both tabs now handle backend unreachable consistently
- Vertically centers the "Get help" button in both alerts
- Updates the help dialog with recovery steps ordered by severity: navigate away and return, disable/re-enable extension, restart Docker Desktop, reboot
- Requires 2 consecutive backend failures before showing the unreachable banner, eliminating flicker when the controller briefly drops during startup or restart

## Test plan

- [x] `make test` passes
- [x] Stop `imds-proxy-controller` — both Containers and Settings tabs show a warning Alert with a centered "Get help" button
- [x] Help dialog shows 4 recovery steps in order of severity
- [ ] Restart `imds-proxy-controller` — alert disappears cleanly without flickering