### PR TITLE
fix: bake versioned proxy image reference into extension image at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN pnpm run build
 FROM alpine
 RUN apk add --no-cache curl
 ARG DESCRIPTION="Description not set"
+ARG PROXY_IMAGE=barnacle-imds-proxy-proxy:latest
 LABEL org.opencontainers.image.title="Barnacle IMDS Proxy" \
     org.opencontainers.image.description="${DESCRIPTION}" \
     org.opencontainers.image.vendor="Matt Miller" \
@@ -42,6 +43,7 @@ LABEL org.opencontainers.image.title="Barnacle IMDS Proxy" \
 
 COPY --from=builder /backend/bin/service /
 COPY docker-compose.yaml .
+RUN sed -i "s|barnacle-imds-proxy-proxy:latest|${PROXY_IMAGE}|" docker-compose.yaml
 COPY metadata.json .
 COPY logo.svg .
 COPY --from=client-builder /ui/build ui

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IMAGE?=imds-dev-proxy
+IMAGE?=barnacle-imds-proxy
 TAG?=latest
 PROXY_IMAGE?=$(IMAGE)-proxy
 
@@ -41,7 +41,7 @@ prepare-buildx: ## Create buildx builder for multi-arch build, if not exists
 	docker buildx inspect $(BUILDER) || docker buildx create --name=$(BUILDER) --driver=docker-container --driver-opt=network=host
 
 push-extension: prepare-buildx ## Build & Upload extension image to hub. Do not push if tag already exists: make push-extension tag=0.1
-	docker pull $(IMAGE):$(TAG) && { echo "Failure: Tag already exists"; exit 1; } || docker buildx build --push --builder=$(BUILDER) --platform=linux/amd64,linux/arm64 --build-arg TAG=$(TAG) --build-arg DESCRIPTION="$(DESCRIPTION)" --tag=$(IMAGE):$(TAG) .
+	docker pull $(IMAGE):$(TAG) && { echo "Failure: Tag already exists"; exit 1; } || docker buildx build --push --builder=$(BUILDER) --platform=linux/amd64,linux/arm64 --build-arg TAG=$(TAG) --build-arg DESCRIPTION="$(DESCRIPTION)" --build-arg PROXY_IMAGE=$(PROXY_IMAGE):$(TAG) --tag=$(IMAGE):$(TAG) .
 	docker pull $(PROXY_IMAGE):$(TAG) && { echo "Failure: Proxy tag already exists"; exit 1; } || docker buildx build --push --builder=$(BUILDER) --platform=linux/amd64,linux/arm64 --tag=$(PROXY_IMAGE):$(TAG) -f Dockerfile.proxy .
 
 # ─── Development ──────────────────────────────────────────────────────────────

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
   # extension's configured backend.
   imds-proxy:
     container_name: imds-proxy
-    image: imds-dev-proxy-proxy:latest
+    image: barnacle-imds-proxy-proxy:latest
     extra_hosts:
       - "host.docker.internal:host-gateway"
     networks:


### PR DESCRIPTION
## Summary

- `docker-compose.yaml` hardcoded the proxy image name, causing Docker Desktop to attempt a registry pull on install rather than using the correct versioned image
- Added a `PROXY_IMAGE` build arg to the Dockerfile that gets substituted into `docker-compose.yaml` via `sed` during the build
- `push-extension` Makefile target now passes the fully-qualified proxy image reference at build time
- Local dev is unchanged; the default arg matches what is built locally

## Test plan

- [x] `make build-extension && make install-extension` -- verify extension installs and proxy starts correctly
- [x] Confirm `docker-compose.yaml` inside the built image contains the correct image reference: `docker run --rm barnacle-imds-proxy:latest cat docker-compose.yaml`
- [x] Install on a machine that has never built the proxy image locally -- verify it pulls correctly rather than failing
